### PR TITLE
Add override geth binary variable

### DIFF
--- a/charts/geth/Chart.yaml
+++ b/charts/geth/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://launchpad.ethereum.org/static/media/gethereum-mascot-circle.75cbd3
 sources:
   - https://github.com/ethereum/go-ethereum
 type: application
-version: 0.3.4
+version: 0.3.5
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/geth/README.md
+++ b/charts/geth/README.md
@@ -1,7 +1,7 @@
 
 # geth
 
-![Version: 0.3.4](https://img.shields.io/badge/Version-0.3.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.3.5](https://img.shields.io/badge/Version-0.3.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Go Ethereum (Geth for short) is one of the original implementations of the Ethereum protocol. Currently, it is the most widespread client with the biggest user base and variety of tooling for users and developers. It is written in Go, fully open source and licensed under the GNU LGPL v3
 
@@ -29,6 +29,7 @@ Go Ethereum (Geth for short) is one of the original implementations of the Ether
 | extraVolumeMounts | list | `[]` | Additional volume mounts |
 | extraVolumes | list | `[]` | Additional volumes |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| gethBinaryOverride | string | `"geth"` | Override geth binary |
 | httpPort | int | `8545` | HTTP Port |
 | image.pullPolicy | string | `"IfNotPresent"` | geth container pull policy |
 | image.repository | string | `"ethereum/client-go"` | geth container image repository |

--- a/charts/geth/templates/_cmd.tpl
+++ b/charts/geth/templates/_cmd.tpl
@@ -8,7 +8,7 @@
 {{- if .Values.p2pNodePort.enabled }}
   . /env/init-nodeport;
 {{- end }}
-  exec geth
+  exec {{ .Values.gethBinaryOverride }}
   --datadir=/data
   --config=/config/geth.toml
 {{- if .Values.p2pNodePort.enabled }}

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -31,6 +31,9 @@ jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 # -- Command replacement for the geth container
 customCommand: [] # Only change this if you need to change the default command
 
+# -- Override geth binary
+gethBinaryOverride: geth
+
 # When p2pNodePort is enabled, your P2P port will be exposed via service type NodePort.
 # This is useful if you want to expose and announce your node to the Internet.
 # Limitation: You can only one have one replica when exposing via NodePort.


### PR DESCRIPTION
Add override geth binary variable.  Needs for HECO fork but maybe useful for other geth forks.