### PR TITLE
smart-contract-verifier-http: fix http port and read config file

### DIFF
--- a/charts/smart-contract-verifier-http/Chart.yaml
+++ b/charts/smart-contract-verifier-http/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/blockscout/blockscout-rs/tree/main/smart-contract-verif
 sources:
   - https://github.com/blockscout/blockscout-rs/tree/main/smart-contract-verifier-http
 type: application
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/smart-contract-verifier-http/README.md
+++ b/charts/smart-contract-verifier-http/README.md
@@ -1,7 +1,7 @@
 
 # smart-contract-verifier-http
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Smart-contract verification service. Runs as an HTTP server and allows making verification requests through REST API.
 
@@ -22,7 +22,7 @@ Smart-contract verification service. Runs as an HTTP server and allows making ve
 | customArgs | list | `[]` | Custom args for the smart-contract-verifier-http container |
 | customCommand | list | `[]` | Command replacement for the smart-contract-verifier-http container |
 | extraContainers | list | `[]` | Additional containers |
-| extraEnv | list | `[]` | Additional env variables |
+| extraEnv | list | `[{"name":"SMART_CONTRACT_VERIFIER__CONFIG","value":"/app/config.toml"}]` | Additional env variables |
 | extraPorts | list | `[]` | Additional ports. Useful when using extraContainers |
 | extraVolumeMounts | list | `[]` | Additional volume mounts |
 | extraVolumes | list | `[]` | Additional volumes |

--- a/charts/smart-contract-verifier-http/templates/_helpers.tpl
+++ b/charts/smart-contract-verifier-http/templates/_helpers.tpl
@@ -62,7 +62,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "smart-contract-verifier-http.httpPort" -}}
-{{- printf "8043" -}}
+{{- printf "8050" -}}
 {{- end -}}
 
 {{- define "smart-contract-verifier-http.metricsPort" -}}

--- a/charts/smart-contract-verifier-http/values.yaml
+++ b/charts/smart-contract-verifier-http/values.yaml
@@ -27,11 +27,17 @@ customCommand: [] # Only change this if you need to change the default command
 secretEnv:
   #SOME_SECRET_ENV_VAR: some-secret
 
+# -- Additional env variables
+extraEnv:
+  - name: SMART_CONTRACT_VERIFIER__CONFIG
+    value: /app/config.toml
+
 # -- Config file
 # @default -- See `values.yaml`
 config: |
-  [server]
-  addr = "0.0.0.0:8043"
+  [server.http]
+  enabled = true
+  addr = "0.0.0.0:{{ include "smart-contract-verifier-http.httpPort" . }}"
 
   [compilers]
   # if omitted, number of CPU cores would be used
@@ -227,10 +233,6 @@ extraVolumeMounts: []
 
 # -- Additional ports. Useful when using extraContainers
 extraPorts: []
-
-# -- Additional env variables
-extraEnv: []
-
 
 serviceMonitor:
   # -- If true, a ServiceMonitor CRD is created for a prometheus operator


### PR DESCRIPTION
It seems like that the config file wasn't been read at all. Adding the `SMART_CONTRACT_VERIFIER__CONFIG` fixed that. Also changed the default http port to be 8050 instead of 8043. The config file also had to change slightly due to the http.server config.  

fixes https://github.com/ethpandaops/ethereum-helm-charts/issues/159