### PR TITLE
add topologySpreadConstraints support

### DIFF
--- a/charts/erigon/README.md
+++ b/charts/erigon/README.md
@@ -97,6 +97,7 @@ Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented
 | serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
 | serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
 | terminationGracePeriodSeconds | int | `300` | How long to wait until the pod is forcefully terminated |
+| topologySpreadConstraints | list | `[]` | Rules used to distribute Pods evenly across nodes or other topological domains |
 | tolerations | list | `[]` | Tolerations for pods |
 | updateStrategy | object | `{"type":"RollingUpdate"}` | Update stategy for the Statefulset |
 | updateStrategy.type | string | `"RollingUpdate"` | Update stategy type |

--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -198,14 +198,15 @@ spec:
         {{- toYaml .Values.affinity | nindent 8 }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      {{- with .topologySpreadConstraints }}
+      {{- if .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
-        {{- range $constraint := . }}
+        {{- range $constraint := .Values.topologySpreadConstraints }}
       - {{ toYaml $constraint | nindent 8 | trim }}
-      {{- end }}
         labelSelector:
-          matchLabels:
+          matchLabels: {{- include "erigon.selectorLabels" $ | nindent 12 }}
+        {{- end }}    
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       volumes:
         - name: jwt
           secret:

--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -199,6 +199,13 @@ spec:
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- with .topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range $constraint := . }}
+      - {{ toYaml $constraint | nindent 8 | trim }}
+      {{- end }}
+        labelSelector:
+          matchLabels:
       volumes:
         - name: jwt
           secret:


### PR DESCRIPTION
Support topologySpreadConstraints to evenly distribute pods across nodes or other topology domains.

Example to use:

```
# Define the topologySpreadConstraints configuration
topologySpreadConstraints:
  # First topology spread constraint
  - maxSkew: 1                         
    # Maximum allowed difference of Pods per node
    topologyKey: kubernetes.io/hostname 
    # Group Pods by node hostname
    whenUnsatisfiable: DoNotSchedule   
    # If constraint is unsatisfiable, don't schedule the Pod
  # Second topology spread constraint
  - maxSkew: 1                         
    # Maximum allowed difference of Pods per zone
    topologyKey: topology.kubernetes.io/zone 
    # Group Pods by zone
    whenUnsatisfiable: DoNotSchedule   
    # If constraint is unsatisfiable, don't schedule the Pod
```