### PR TITLE
ci: add timeout and debug logs for ct

### DIFF
--- a/ct.yaml
+++ b/ct.yaml
@@ -1,5 +1,7 @@
 # This is the CT (chart testing) config file
 # More infos under https://github.com/helm/chart-testing#configuration
+kubectl-timeout: 60s
+debug: true
 remote: origin
 target-branch: master
 chart-dirs:


### PR DESCRIPTION
With `debug=true` we'll get all kubectl/helm commands that ct is executing.
