### PR TITLE
beacon-metrics-gazer: fixup indentation

### DIFF
--- a/charts/beacon-metrics-gazer/Chart.yaml
+++ b/charts/beacon-metrics-gazer/Chart.yaml
@@ -3,7 +3,7 @@ name: beacon-metrics-gazer
 description: Collects network wide participation metrics given a range of indexes
 home: https://github.com/dapplion/beacon-metrics-gazer
 type: application
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/beacon-metrics-gazer/README.md
+++ b/charts/beacon-metrics-gazer/README.md
@@ -1,7 +1,7 @@
 
 # beacon-metrics-gazer
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Collects network wide participation metrics given a range of indexes
 

--- a/charts/beacon-metrics-gazer/templates/deployment.yaml
+++ b/charts/beacon-metrics-gazer/templates/deployment.yaml
@@ -39,56 +39,56 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-      - name: {{ .Chart.Name }}
-        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command:
-        {{- if gt (len .Values.customCommand) 0 }}
-          {{- toYaml .Values.customCommand | nindent 12}}
-        {{- else }}
-            - /beacon-metrics-gazer
-            - {{ .Values.endpoint }}
-            - --ranges-file 
-            - /data/ranges.yaml
-            - --port 
-            - "{{ .Values.httpPort }}"
-            - --address
-            - "0.0.0.0"
-        {{- end }}
-        {{- if gt (len .Values.extraArgs) 0 }}
-        args:
-          {{- toYaml .Values.extraArgs | nindent 12}}
-        {{- end }}
-        securityContext:
-          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
-        volumeMounts:
-          - name: ranges
-            mountPath: "/data/ranges.yaml"
-            subPath: ranges.yaml
-            readOnly: true
-          {{- if .Values.extraVolumeMounts }}
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          {{- if gt (len .Values.customCommand) 0 }}
+            {{- toYaml .Values.customCommand | nindent 12}}
+          {{- else }}
+              - /beacon-metrics-gazer
+              - {{ .Values.endpoint }}
+              - --ranges-file
+              - /data/ranges.yaml
+              - --port
+              - "{{ .Values.httpPort }}"
+              - --address
+              - "0.0.0.0"
+          {{- end }}
+          {{- if gt (len .Values.extraArgs) 0 }}
+          args:
+            {{- toYaml .Values.extraArgs | nindent 12}}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: ranges
+              mountPath: "/data/ranges.yaml"
+              subPath: ranges.yaml
+              readOnly: true
+            {{- if .Values.extraVolumeMounts }}
             {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.httpPort }}
+              protocol: TCP
+            {{- if .Values.extraPodPorts }}
+            {{ toYaml .Values.extraPodPorts | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+          {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
           {{- end }}
-        ports:
-          - name: http
-            containerPort: {{ .Values.httpPort }}
-            protocol: TCP
-          {{- if .Values.extraPodPorts }}
-            {{ toYaml .Values.extraPodPorts | nindent 10 }}
-          {{- end }}
-        livenessProbe:
-          {{- toYaml .Values.livenessProbe | nindent 12 }}
-        readinessProbe:
-          {{- toYaml .Values.readinessProbe | nindent 12 }}
-        resources:
-          {{- toYaml .Values.resources | nindent 12 }}
-        env:
-        {{- if .Values.extraEnv }}
-          {{- toYaml .Values.extraEnv | nindent 12 }}
-        {{- end }}
-      {{- if .Values.extraContainers }}
+        {{- if .Values.extraContainers }}
         {{ toYaml .Values.extraContainers | nindent 8}}
-      {{- end }}
+        {{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       affinity:


### PR DESCRIPTION
hard to review just by looking at the code diff, but basically nindent was off by 2. Because it was:
```yaml
containers:
- ...
```
instead of :
```yaml
containers:
  - ...
```

This came to my attention due to a custom deployment I was doing when setting extraVolumeMounts:

```

ComparisonError: rpc error: code = Unknown desc = Manifest generation error (cached): `bash -c VALUES_FILES="" for i in ${ARGOCD_ENV_HELM_OPTIONAL_VALUES_FILES//,/ } do if [ -f "${i}" ]; then VALUES_FILES="${VALUES_FILES} -f ${i}" fi done helm template $ARGOCD_APP_NAME -n $ARGOCD_APP_NAMESPACE ${VALUES_FILES[@]} ${ARGOCD_ENV_HELM_ARGS} --include-crds -f <(echo "$ARGOCD_ENV_HELM_VALUES") . | AVP_TYPE=sops SOPS_AGE_KEY_FILE=/keys/key argocd-vault-plugin generate - ` failed exit status 1: Error: YAML parse error on sepolia-beacon-metrics-gazer/charts/beacon-metrics-gazer/templates/deployment.yaml: error converting YAML to JSON: yaml: line 67: did not find expected key Use --debug flag to render out invalid YAML Error: No manifests Usage: argocd-vault-plugin generate <path> [flags] Flags: -c, --config-path string path to a file containing Vault configuration (YAML, JSON, envfile) to use -h, --help help for generate -s, --secret-name string name of a Kubernetes Secret in the argocd namespace containing Vault configuration data in the argocd namespace of your ArgoCD host (Only available when used in ArgoCD). The namespace can be overridden by using the format <namespace>:<name>
```