### PR TITLE
ethereum clients: fixup p2p nodeport

### DIFF
--- a/charts/besu/Chart.yaml
+++ b/charts/besu/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://launchpad.ethereum.org/static/media/hyperledger-besu-circle.b96368
 sources:
   - https://github.com/hyperledger/besu
 type: application
-version: 1.0.4
+version: 1.0.5
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/besu/README.md
+++ b/charts/besu/README.md
@@ -1,7 +1,7 @@
 
 # besu
 
-![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An Ethereum execution layer client designed to be enterprise-friendly for both public and private, permissioned network use cases. Besu is written in Java and released under the Apache 2.0 Licence.
 
@@ -57,6 +57,7 @@ An Ethereum execution layer client designed to be enterprise-friendly for both p
 | p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
 | p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
+| p2pPort | int | `30303` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
 | persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |

--- a/charts/besu/templates/_helpers.tpl
+++ b/charts/besu/templates/_helpers.tpl
@@ -70,17 +70,17 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "besu.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
-{{- printf "30303" -}}
+{{- print .Values.p2pPort }}
 {{- end }}
 {{- end -}}
 
 {{- define "besu.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/besu/templates/_helpers.tpl
+++ b/charts/besu/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "besu.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "besu.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/besu/templates/service.p2p.nodeport.yaml
+++ b/charts/besu/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "besu.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "besu.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "besu.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "besu.p2pPort" $ }}
   selector:
     {{- include "besu.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "besu.fullname" $ }}-0"

--- a/charts/besu/values.yaml
+++ b/charts/besu/values.yaml
@@ -138,6 +138,9 @@ readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 10
 
+# -- P2P Port
+p2pPort: 30303
+
 # -- HTTP Port
 httpPort: 8545
 

--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://pbs.twimg.com/profile_images/1420080204148576274/-4OFIs2x_400x400.
 sources:
   - https://github.com/ledgerwatch/erigon
 type: application
-version: 1.0.5
+version: 1.0.6
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/erigon/README.md
+++ b/charts/erigon/README.md
@@ -1,7 +1,7 @@
 
 # erigon
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented toward speed and disk‐space efficiency. Erigon is a completely re-architected implementation of Ethereum, currently written in Go but with implementations in other languages planned. Erigon's goal is to provide a faster, more modular, and more optimized implementation of Ethereum.
 
@@ -62,6 +62,7 @@ Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented
 | p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
 | p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
+| p2pPort | int | `30303` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
 | persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |

--- a/charts/erigon/templates/_helpers.tpl
+++ b/charts/erigon/templates/_helpers.tpl
@@ -70,17 +70,17 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "erigon.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
-{{- printf "30303" -}}
+{{- print .Values.p2pPort }}
 {{- end }}
 {{- end -}}
 
 {{- define "erigon.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/erigon/templates/_helpers.tpl
+++ b/charts/erigon/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "erigon.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "erigon.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/erigon/templates/service.p2p.nodeport.yaml
+++ b/charts/erigon/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "erigon.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "erigon.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "erigon.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "erigon.p2pPort" $ }}
   selector:
     {{- include "erigon.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "erigon.fullname" $ }}-0"

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -177,6 +177,9 @@ readinessProbeRPCDaemon:
   initialDelaySeconds: 10
   periodSeconds: 10
 
+# -- P2P Port
+p2pPort: 30303
+
 # -- HTTP Port
 httpPort: 8545
 

--- a/charts/ethereum-node/Chart.lock
+++ b/charts/ethereum-node/Chart.lock
@@ -1,22 +1,22 @@
 dependencies:
 - name: besu
   repository: file://../besu
-  version: 1.0.4
+  version: 1.0.5
 - name: erigon
   repository: file://../erigon
-  version: 1.0.5
+  version: 1.0.6
 - name: ethereumjs
   repository: file://../ethereumjs
-  version: 0.0.4
+  version: 0.0.5
 - name: geth
   repository: file://../geth
-  version: 1.0.5
+  version: 1.0.6
 - name: nethermind
   repository: file://../nethermind
-  version: 1.0.6
+  version: 1.0.7
 - name: reth
   repository: file://../reth
-  version: 0.0.3
+  version: 0.0.4
 - name: grandine
   repository: file://../grandine
   version: 0.1.0
@@ -41,5 +41,5 @@ dependencies:
 - name: xatu-sentry
   repository: file://../xatu-sentry
   version: 0.0.7
-digest: sha256:060f485952c73f4045b91c512e9229e2b9543a30e62636d68eccb22a86a6e333
-generated: "2023-07-13T13:44:19.907525+02:00"
+digest: sha256:25d00f8520bfe5c119edea6b1260e9d737375b66998fe7da3b41b5d87ac39fd7
+generated: "2023-07-13T14:36:57.534782+02:00"

--- a/charts/ethereum-node/Chart.lock
+++ b/charts/ethereum-node/Chart.lock
@@ -19,27 +19,27 @@ dependencies:
   version: 0.0.3
 - name: grandine
   repository: file://../grandine
-  version: 0.0.3
+  version: 0.1.0
 - name: lighthouse
   repository: file://../lighthouse
-  version: 1.0.5
+  version: 1.1.0
 - name: teku
   repository: file://../teku
-  version: 1.0.5
+  version: 1.1.0
 - name: prysm
   repository: file://../prysm
-  version: 1.0.5
+  version: 1.1.0
 - name: nimbus
   repository: file://../nimbus
-  version: 1.0.6
+  version: 1.1.0
 - name: lodestar
   repository: file://../lodestar
-  version: 1.0.6
+  version: 1.1.0
 - name: ethereum-metrics-exporter
   repository: file://../ethereum-metrics-exporter
   version: 0.1.4
 - name: xatu-sentry
   repository: file://../xatu-sentry
   version: 0.0.7
-digest: sha256:75f5145aa39bb5366011e9dbed500d1933b40e6d2b4807a2af184d41756f6f06
-generated: "2023-06-20T16:08:09.543527+02:00"
+digest: sha256:060f485952c73f4045b91c512e9229e2b9543a30e62636d68eccb22a86a6e333
+generated: "2023-07-13T13:44:19.907525+02:00"

--- a/charts/ethereum-node/Chart.yaml
+++ b/charts/ethereum-node/Chart.yaml
@@ -15,32 +15,32 @@ maintainers:
 
 dependencies:
 - name: besu
-  version: "1.0.4"
+  version: "1.0.5"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../besu"
   condition: besu.enabled
 - name: erigon
-  version: "1.0.5"
+  version: "1.0.6"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../erigon"
   condition: erigon.enabled
 - name: ethereumjs
-  version: "0.0.4"
+  version: "0.0.5"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../ethereumjs"
   condition: ethereumjs.enabled
 - name: geth
-  version: "1.0.5"
+  version: "1.0.6"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../geth"
   condition: geth.enabled
 - name: nethermind
-  version: "1.0.6"
+  version: "1.0.7"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../nethermind"
   condition: nethermind.enabled
 - name: reth
-  version: "0.0.3"
+  version: "0.0.4"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../reth"
   condition: reth.enabled

--- a/charts/ethereum-node/Chart.yaml
+++ b/charts/ethereum-node/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/6250754?s=200&v=4
 sources:
   - https://github.com/ethpandaops/ethereum-helm-charts
 type: application
-version: 0.0.8
+version: 0.0.9
 maintainers:
   - name: skylenet
     email: rafael@skyle.net
@@ -46,32 +46,32 @@ dependencies:
   condition: reth.enabled
 
 - name: grandine
-  version: "0.0.3"
+  version: "0.1.0"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../grandine"
   condition: grandine.enabled
 - name: lighthouse
-  version: "1.0.5"
+  version: "1.1.0"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../lighthouse"
   condition: lighthouse.enabled
 - name: teku
-  version: "1.0.5"
+  version: "1.1.0"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../teku"
   condition: teku.enabled
 - name: prysm
-  version: "1.0.5"
+  version: "1.1.0"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../prysm"
   condition: prysm.enabled
 - name: nimbus
-  version: "1.0.6"
+  version: "1.1.0"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../nimbus"
   condition: nimbus.enabled
 - name: lodestar
-  version: "1.0.6"
+  version: "1.1.0"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../lodestar"
   condition: lodestar.enabled

--- a/charts/ethereum-node/README.md
+++ b/charts/ethereum-node/README.md
@@ -14,18 +14,18 @@ This chart acts as an umbrella chart and allows to run a ethereum execution and 
 ## Subcharts
 | Repository | Name | Version |
 |------------|------|---------|
-| file://../besu | besu | 1.0.4 |
-| file://../erigon | erigon | 1.0.5 |
+| file://../besu | besu | 1.0.5 |
+| file://../erigon | erigon | 1.0.6 |
 | file://../ethereum-metrics-exporter | ethereum-metrics-exporter | 0.1.4 |
-| file://../ethereumjs | ethereumjs | 0.0.4 |
-| file://../geth | geth | 1.0.5 |
+| file://../ethereumjs | ethereumjs | 0.0.5 |
+| file://../geth | geth | 1.0.6 |
 | file://../grandine | grandine | 0.1.0 |
 | file://../lighthouse | lighthouse | 1.1.0 |
 | file://../lodestar | lodestar | 1.1.0 |
-| file://../nethermind | nethermind | 1.0.6 |
+| file://../nethermind | nethermind | 1.0.7 |
 | file://../nimbus | nimbus | 1.1.0 |
 | file://../prysm | prysm | 1.1.0 |
-| file://../reth | reth | 0.0.3 |
+| file://../reth | reth | 0.0.4 |
 | file://../teku | teku | 1.1.0 |
 | file://../xatu-sentry | xatu-sentry | 0.0.7 |
 

--- a/charts/ethereum-node/README.md
+++ b/charts/ethereum-node/README.md
@@ -1,7 +1,7 @@
 
 # ethereum-node
 
-![Version: 0.0.8](https://img.shields.io/badge/Version-0.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This chart acts as an umbrella chart and allows to run a ethereum execution and consensus layer client. It's also able to deploy optional monitoring applications.
 
@@ -19,14 +19,14 @@ This chart acts as an umbrella chart and allows to run a ethereum execution and 
 | file://../ethereum-metrics-exporter | ethereum-metrics-exporter | 0.1.4 |
 | file://../ethereumjs | ethereumjs | 0.0.4 |
 | file://../geth | geth | 1.0.5 |
-| file://../grandine | grandine | 0.0.3 |
-| file://../lighthouse | lighthouse | 1.0.5 |
-| file://../lodestar | lodestar | 1.0.6 |
+| file://../grandine | grandine | 0.1.0 |
+| file://../lighthouse | lighthouse | 1.1.0 |
+| file://../lodestar | lodestar | 1.1.0 |
 | file://../nethermind | nethermind | 1.0.6 |
-| file://../nimbus | nimbus | 1.0.6 |
-| file://../prysm | prysm | 1.0.5 |
+| file://../nimbus | nimbus | 1.1.0 |
+| file://../prysm | prysm | 1.1.0 |
 | file://../reth | reth | 0.0.3 |
-| file://../teku | teku | 1.0.5 |
+| file://../teku | teku | 1.1.0 |
 | file://../xatu-sentry | xatu-sentry | 0.0.7 |
 
 # Details

--- a/charts/ethereum-node/values.yaml
+++ b/charts/ethereum-node/values.yaml
@@ -93,6 +93,7 @@ besu:
   enabled: false
   nameOverride: execution
   httpPort: 8545
+  p2pPort: 30303
   extraArgs:
     - >-
       {{- with( index .Values.global.clientArgs.networks .Values.global.main.network ) }}
@@ -109,6 +110,7 @@ erigon:
   enabled: false
   nameOverride: execution
   httpPort: 8545
+  p2pPort: 30303
   extraArgs:
     - >-
       {{- with( index .Values.global.clientArgs.networks .Values.global.main.network ) }}
@@ -125,6 +127,7 @@ ethereumjs:
   enabled: false
   nameOverride: execution
   rpcPort: 8545
+  p2pPort: 30303
   extraArgs:
     - >-
       {{- with( index .Values.global.clientArgs.networks .Values.global.main.network ) }}
@@ -141,6 +144,7 @@ geth:
   enabled: false
   nameOverride: execution
   httpPort: 8545
+  p2pPort: 30303
   extraArgs:
     - >-
       {{- with( index .Values.global.clientArgs.networks .Values.global.main.network ) }}
@@ -157,6 +161,7 @@ nethermind:
   enabled: false
   nameOverride: execution
   httpPort: 8545
+  p2pPort: 30303
   extraArgs:
     - >-
       {{- with( index .Values.global.clientArgs.networks .Values.global.main.network ) }}
@@ -173,6 +178,7 @@ reth:
   enabled: false
   nameOverride: execution
   httpPort: 8545
+  p2pPort: 30303
   extraArgs:
     - >-
       {{- with( index .Values.global.clientArgs.networks .Values.global.main.network ) }}

--- a/charts/ethereumjs/Chart.yaml
+++ b/charts/ethereumjs/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://user-images.githubusercontent.com/47108/78779352-d0839500-796a-11e
 sources:
   - https://github.com/ethereumjs/ethereumjs-monorepo
 type: application
-version: 0.0.4
+version: 0.0.5
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/ethereumjs/README.md
+++ b/charts/ethereumjs/README.md
@@ -1,7 +1,7 @@
 
 # ethereumjs
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 The EthereumJS Client is an Ethereum Execution Client (similar to go-ethereum or Nethermind) written in TypeScript/JavaScript, the non-Smart-Contract language Ethereum dApp developers are most familiar with. It is targeted to be a client for research and development and not meant to be used in production on mainnet for the foreseeable future (out of resource and security considerations).
 
@@ -57,6 +57,7 @@ The EthereumJS Client is an Ethereum Execution Client (similar to go-ethereum or
 | p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
 | p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
+| p2pPort | int | `30303` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
 | persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |

--- a/charts/ethereumjs/templates/_helpers.tpl
+++ b/charts/ethereumjs/templates/_helpers.tpl
@@ -70,17 +70,17 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "ethereumjs.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
-{{- printf "30303" -}}
+{{- print .Values.p2pPort }}
 {{- end }}
 {{- end -}}
 
 {{- define "ethereumjs.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/ethereumjs/templates/_helpers.tpl
+++ b/charts/ethereumjs/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "ethereumjs.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "ethereumjs.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/ethereumjs/templates/service.p2p.nodeport.yaml
+++ b/charts/ethereumjs/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "ethereumjs.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "ethereumjs.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "ethereumjs.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "ethereumjs.p2pPort" $ }}
   selector:
     {{- include "ethereumjs.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "ethereumjs.fullname" $ }}-0"

--- a/charts/ethereumjs/values.yaml
+++ b/charts/ethereumjs/values.yaml
@@ -139,6 +139,9 @@ readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 10
 
+# -- P2P Port
+p2pPort: 30303
+
 # -- HTTP Port
 rpcPort: 8545
 

--- a/charts/geth/Chart.yaml
+++ b/charts/geth/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://launchpad.ethereum.org/static/media/gethereum-mascot-circle.75cbd3
 sources:
   - https://github.com/ethereum/go-ethereum
 type: application
-version: 1.0.5
+version: 1.0.6
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/geth/README.md
+++ b/charts/geth/README.md
@@ -1,7 +1,7 @@
 
 # geth
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Go Ethereum (Geth for short) is one of the original implementations of the Ethereum protocol. Currently, it is the most widespread client with the biggest user base and variety of tooling for users and developers. It is written in Go, fully open source and licensed under the GNU LGPL v3
 
@@ -59,6 +59,7 @@ Go Ethereum (Geth for short) is one of the original implementations of the Ether
 | p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
 | p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
+| p2pPort | int | `30303` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
 | persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |

--- a/charts/geth/templates/_helpers.tpl
+++ b/charts/geth/templates/_helpers.tpl
@@ -70,17 +70,17 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "geth.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
-{{- printf "30303" -}}
+{{- print .Values.p2pPort }}
 {{- end }}
 {{- end -}}
 
 {{- define "geth.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/geth/templates/_helpers.tpl
+++ b/charts/geth/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "geth.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "geth.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/geth/templates/service.p2p.nodeport.yaml
+++ b/charts/geth/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "geth.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "geth.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "geth.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "geth.p2pPort" $ }}
   selector:
     {{- include "geth.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "geth.fullname" $ }}-0"

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -146,6 +146,9 @@ readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 10
 
+# -- P2P Port
+p2pPort: 30303
+
 # -- HTTP Port
 httpPort: 8545
 

--- a/charts/grandine/Chart.yaml
+++ b/charts/grandine/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://github.com/sifraitech/grandine/blob/master/gui.png
 sources:
   - https://github.com/sifraitech/grandine
 type: application
-version: 0.0.3
+version: 0.1.0
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/grandine/README.md
+++ b/charts/grandine/README.md
@@ -1,7 +1,7 @@
 
 # grandine
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A currently closed source, but hopefully soon to be open-source Ethereum Consensus layer client, written in Rust.
 
@@ -19,7 +19,7 @@ A currently closed source, but hopefully soon to be open-source Ethereum Consens
 | annotations | object | `{}` | Annotations for the StatefulSet |
 | checkpointSync | object | `{"enabled":false,"url":""}` | Checkpoint Sync |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
-| customCommand | list | `[]` |  |
+| customCommand | list | `[]` | Legacy way of overwriting the default command. You may prefer to change defaultCommandTemplates instead. |
 | defaultBeaconCommandTemplate | string | See `values.yaml` | Template used for the default beacon command |
 | extraArgs | list | `[]` | Extra args for the grandine container |
 | extraContainers | list | `[]` | Additional containers |
@@ -53,8 +53,7 @@ A currently closed source, but hopefully soon to be open-source Ethereum Consens
 | p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
 | p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
-| p2pNodePort.portsOverwrite | object | See `values.yaml` for example | Overwrite a port for specific replicas |
-| p2pNodePort.startAt | int | `31000` | Port used to start |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
 | p2pPort | int | `9000` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
@@ -107,28 +106,20 @@ extraArgs:
   - --ee-endpoint=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 beacon nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
 
 ## Validator node targeting a beacon node service
 

--- a/charts/grandine/README.md.gotmpl
+++ b/charts/grandine/README.md.gotmpl
@@ -26,28 +26,20 @@ extraArgs:
   - --ee-endpoint=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 beacon nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
 
 
 ## Validator node targeting a beacon node service

--- a/charts/grandine/templates/_helpers.tpl
+++ b/charts/grandine/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "grandine.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,9 +78,9 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "grandine.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/grandine/templates/_helpers.tpl
+++ b/charts/grandine/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "grandine.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "grandine.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/grandine/templates/_helpers.tpl
+++ b/charts/grandine/templates/_helpers.tpl
@@ -68,3 +68,19 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- define "grandine.clusterRoleName" -}}
 {{ .Release.Namespace }}-{{ include "grandine.fullname" . }}
 {{- end }}
+
+{{- define "grandine.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
+{{- print .Values.p2pPort }}
+{{- end }}
+{{- end -}}
+
+{{- define "grandine.replicas" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end}}
+{{- end -}}

--- a/charts/grandine/templates/service-headless.yaml
+++ b/charts/grandine/templates/service-headless.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "grandine.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "grandine.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/grandine/templates/service.p2p.nodeport.yaml
+++ b/charts/grandine/templates/service.p2p.nodeport.yaml
@@ -1,11 +1,6 @@
 {{- if .Values.p2pNodePort.enabled -}}
 
-{{- range $i, $e := until (int $.Values.replicas) }}
-
-{{- $port := add $.Values.p2pNodePort.startAt $i -}}
-{{- if hasKey $.Values.p2pNodePort.portsOverwrite ($i | toString) -}}
-  {{ $port = index $.Values.p2pNodePort.portsOverwrite ($i | toString) }}
-{{- end }}
+{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -20,19 +15,16 @@ spec:
   externalTrafficPolicy: Local
   ports:
     - name: p2p-tcp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "grandine.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
       nodePort: {{ $port }}
     - name: p2p-udp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "grandine.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
       nodePort: {{ $port }}
   selector:
     {{- include "grandine.selectorLabels" $ | nindent 4 }}
-    statefulset.kubernetes.io/pod-name: {{ include "grandine.fullname" $ }}-{{ $i }}
-
-{{- end }}
-
+    statefulset.kubernetes.io/pod-name: "{{ include "grandine.fullname" $ }}-0"
 {{- end }}

--- a/charts/grandine/templates/service.p2p.nodeport.yaml
+++ b/charts/grandine/templates/service.p2p.nodeport.yaml
@@ -5,10 +5,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "grandine.fullname" $ }}-p2p-{{ $i }}
+  name: {{ include "grandine.fullname" $ }}-p2p-0
   labels:
     {{- include "grandine.labels" $ | nindent 4 }}
-    pod: {{ include "grandine.fullname" $ }}-{{ $i }}
+    pod: {{ include "grandine.fullname" $ }}-0
     type: p2p
 spec:
   type: NodePort

--- a/charts/grandine/templates/service.p2p.nodeport.yaml
+++ b/charts/grandine/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "grandine.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "grandine.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "grandine.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "grandine.p2pPort" $ }}
   selector:
     {{- include "grandine.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "grandine.fullname" $ }}-0"

--- a/charts/grandine/templates/service.yaml
+++ b/charts/grandine/templates/service.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "grandine.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "grandine.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/grandine/templates/statefulset.yaml
+++ b/charts/grandine/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{ include "grandine.replicas" . }}
   selector:
     matchLabels:
       {{- include "grandine.selectorLabels" . | nindent 6 }}
@@ -113,10 +113,10 @@ spec:
               readOnly: true
           ports:
             - name: p2p-tcp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "grandine.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "grandine.p2pPort" . }}
               protocol: UDP
             - name: http-api
               containerPort: {{ .Values.httpPort }}

--- a/charts/grandine/values.yaml
+++ b/charts/grandine/values.yaml
@@ -40,9 +40,30 @@ defaultBeaconCommandTemplate: |
   {{- end }}
     exec grandine
     --data-dir=/data
-    --libp2p-port={{ .Values.p2pPort }}
+    --libp2p-port={{ include "grandine.p2pPort" . }}
     --http-address=0.0.0.0
     --http-port={{ .Values.httpPort }}
+  {{- if .Values.p2pNodePort.enabled }}
+    {{- if not (contains "--enr-address=" (.Values.extraArgs | join ",")) }}
+    --enr-address=$EXTERNAL_IP
+    {{- end }}
+    {{- if not (contains "--enr-tcp-port=" (.Values.extraArgs | join ",")) }}
+    --enr-tcp-port=$EXTERNAL_PORT
+    {{- end }}
+    {{- if not (contains "--enr-udp-port=" (.Values.extraArgs | join ",")) }}
+    --enr-udp-port=$EXTERNAL_PORT
+    {{- end }}
+    {{- else }}
+    {{- if not (contains "--enr-address=" (.Values.extraArgs | join ",")) }}
+    --enr-address=$(POD_IP)
+    {{- end }}
+    {{- if not (contains "--enr-tcp-port=" (.Values.extraArgs | join ",")) }}
+    --enr-tcp-port={{ include "grandine.p2pPort" . }}
+    {{- end }}
+    {{- if not (contains "--enr-udp-port=" (.Values.extraArgs | join ",")) }}
+    --enr-udp-port={{ include "grandine.p2pPort" . }}
+    {{- end }}
+  {{- end }}
     --metrics
     --metrics-address=0.0.0.0
     --metrics-port={{ .Values.metricsPort }}
@@ -54,23 +75,6 @@ defaultBeaconCommandTemplate: |
     {{ tpl . $  }}
   {{- end }}
 
-# P2P Advertised IP and Port is currently not supported by Grandine
-# {{- if .Values.p2pNodePort.enabled }}
-#   {{- if not (contains "--p2p-advertised-ip=" (.Values.extraArgs | join ",")) }}
-#   --p2p-advertised-ip=$EXTERNAL_IP
-#   {{- end }}
-#   {{- if not (contains "--p2p-advertised-port=" (.Values.extraArgs | join ",")) }}
-#   --p2p-advertised-port=$EXTERNAL_PORT
-#   {{- end }}
-# {{- else }}
-#   {{- if not (contains "--p2p-advertised-ip=" (.Values.extraArgs | join ",")) }}
-#   --p2p-advertised-ip=$(POD_IP)
-#   {{- end }}
-#   {{- if not (contains "--p2p-advertised-port=" (.Values.extraArgs | join ",")) }}
-#   --p2p-advertised-port={{ .Values.p2pPort }}
-#   {{- end }}
-# {{- end }}
-
 # -- Legacy way of overwriting the default command. You may prefer to change defaultCommandTemplates instead.
 customCommand: []
 
@@ -80,13 +84,8 @@ customCommand: []
 p2pNodePort:
   # -- Expose P2P port via NodePort
   enabled: false
-  # -- Port used to start
-  startAt: 31000
-  # -- Overwrite a port for specific replicas
-  # @default -- See `values.yaml` for example
-  portsOverwrite: {}
-  #  "0": 32345
-  #  "3": 32348
+  # -- NodePort to be used
+  port: 31000
   initContainer:
     image:
       # -- Container image to fetch nodeport information

--- a/charts/lighthouse/Chart.yaml
+++ b/charts/lighthouse/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/lighthouse-circle.e0b82d14.png
 sources:
   - https://github.com/sigp/lighthouse
 type: application
-version: 1.0.5
+version: 1.1.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -1,7 +1,7 @@
 
 # lighthouse
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum 2.0 client, written in Rust
 
@@ -56,8 +56,7 @@ An open-source Ethereum 2.0 client, written in Rust
 | p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
 | p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
-| p2pNodePort.portsOverwrite | object | See `values.yaml` for example | Overwrite a port for specific replicas |
-| p2pNodePort.startAt | int | `31000` | Port used to start |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
 | p2pPort | int | `9000` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
@@ -110,28 +109,20 @@ extraArgs:
   - --execution-endpoint=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 beacon nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
 
 ## Validator node targeting a beacon node service
 

--- a/charts/lighthouse/README.md.gotmpl
+++ b/charts/lighthouse/README.md.gotmpl
@@ -26,29 +26,20 @@ extraArgs:
   - --execution-endpoint=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 beacon nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
-
 
 ## Validator node targeting a beacon node service
 

--- a/charts/lighthouse/templates/_helpers.tpl
+++ b/charts/lighthouse/templates/_helpers.tpl
@@ -68,3 +68,19 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "lighthouse.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
+{{- print .Values.p2pPort }}
+{{- end }}
+{{- end -}}
+
+{{- define "lighthouse.replicas" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end}}
+{{- end -}}

--- a/charts/lighthouse/templates/_helpers.tpl
+++ b/charts/lighthouse/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "lighthouse.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,9 +78,9 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "lighthouse.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/lighthouse/templates/_helpers.tpl
+++ b/charts/lighthouse/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "lighthouse.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ Create the name of the service account to use
 {{- end -}}
 
 {{- define "lighthouse.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/lighthouse/templates/service-headless.yaml
+++ b/charts/lighthouse/templates/service-headless.yaml
@@ -8,11 +8,11 @@ spec:
   clusterIP: None
   ports:
   {{- if or (eq .Values.mode "beacon") (eq .Values.mode "bootnode") }}
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "prysm.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "prysm.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/lighthouse/templates/service-headless.yaml
+++ b/charts/lighthouse/templates/service-headless.yaml
@@ -8,11 +8,11 @@ spec:
   clusterIP: None
   ports:
   {{- if or (eq .Values.mode "beacon") (eq .Values.mode "bootnode") }}
-    - port: {{ include "prysm.p2pPort" . }}
+    - port: {{ include "lighthouse.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ include "prysm.p2pPort" . }}
+    - port: {{ include "lighthouse.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/lighthouse/templates/service.p2p.nodeport.yaml
+++ b/charts/lighthouse/templates/service.p2p.nodeport.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.p2pNodePort.enabled -}}
-{{- if or (eq .Values.mode "beacon") (eq .Values.mode "bootnode") }}
 
-{{- range $i, $e := until (int $.Values.replicas) }}
-
-{{- $port := add $.Values.p2pNodePort.startAt $i -}}
-{{- if hasKey $.Values.p2pNodePort.portsOverwrite ($i | toString) -}}
-  {{ $port = index $.Values.p2pNodePort.portsOverwrite ($i | toString) }}
-{{- end }}
+{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -21,20 +15,16 @@ spec:
   externalTrafficPolicy: Local
   ports:
     - name: p2p-tcp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "lighthouse.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
       nodePort: {{ $port }}
     - name: p2p-udp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "lighthouse.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
       nodePort: {{ $port }}
   selector:
     {{- include "lighthouse.selectorLabels" $ | nindent 4 }}
-    statefulset.kubernetes.io/pod-name: {{ include "lighthouse.fullname" $ }}-{{ $i }}
-
-{{- end }}
-
-{{- end }}
+    statefulset.kubernetes.io/pod-name: "{{ include "lighthouse.fullname" $ }}-0"
 {{- end }}

--- a/charts/lighthouse/templates/service.p2p.nodeport.yaml
+++ b/charts/lighthouse/templates/service.p2p.nodeport.yaml
@@ -5,10 +5,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "lighthouse.fullname" $ }}-p2p-{{ $i }}
+  name: {{ include "lighthouse.fullname" $ }}-p2p-0
   labels:
     {{- include "lighthouse.labels" $ | nindent 4 }}
-    pod: {{ include "lighthouse.fullname" $ }}-{{ $i }}
+    pod: {{ include "lighthouse.fullname" $ }}-0
     type: p2p
 spec:
   type: NodePort

--- a/charts/lighthouse/templates/service.p2p.nodeport.yaml
+++ b/charts/lighthouse/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "lighthouse.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "lighthouse.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "lighthouse.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "lighthouse.p2pPort" $ }}
   selector:
     {{- include "lighthouse.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "lighthouse.fullname" $ }}-0"

--- a/charts/lighthouse/templates/service.yaml
+++ b/charts/lighthouse/templates/service.yaml
@@ -8,11 +8,11 @@ spec:
   type: ClusterIP
   ports:
   {{- if or (eq .Values.mode "beacon") (eq .Values.mode "bootnode") }}
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "prysm.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "prysm.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/lighthouse/templates/service.yaml
+++ b/charts/lighthouse/templates/service.yaml
@@ -8,11 +8,11 @@ spec:
   type: ClusterIP
   ports:
   {{- if or (eq .Values.mode "beacon") (eq .Values.mode "bootnode") }}
-    - port: {{ include "prysm.p2pPort" . }}
+    - port: {{ include "lighthouse.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ include "prysm.p2pPort" . }}
+    - port: {{ include "lighthouse.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/lighthouse/templates/servicemonitor.yaml
+++ b/charts/lighthouse/templates/servicemonitor.yaml
@@ -41,5 +41,5 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-{{- end}}
+{{- end }}
 {{- end }}

--- a/charts/lighthouse/templates/statefulset.yaml
+++ b/charts/lighthouse/templates/statefulset.yaml
@@ -118,10 +118,10 @@ spec:
           ports:
           {{- if or (eq .Values.mode "beacon") (eq .Values.mode "bootnode") }}
             - name: p2p-tcp
-              containerPort: {{ include "prysm.p2pPort" . }}
+              containerPort: {{ include "lighthouse.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ include "prysm.p2pPort" . }}
+              containerPort: {{ include "lighthouse.p2pPort" . }}
               protocol: UDP
           {{- end }}
           {{- if or (eq .Values.mode "beacon") (eq .Values.mode "validator") }}

--- a/charts/lighthouse/templates/statefulset.yaml
+++ b/charts/lighthouse/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{ include "lighthouse.replicas" . }}
   selector:
     matchLabels:
       {{- include "lighthouse.selectorLabels" . | nindent 6 }}
@@ -118,10 +118,10 @@ spec:
           ports:
           {{- if or (eq .Values.mode "beacon") (eq .Values.mode "bootnode") }}
             - name: p2p-tcp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "prysm.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "prysm.p2pPort" . }}
               protocol: UDP
           {{- end }}
           {{- if or (eq .Values.mode "beacon") (eq .Values.mode "validator") }}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -67,15 +67,15 @@ defaultBeaconCommandTemplate: |
     --enr-address=$(POD_IP)
     {{- end }}
     {{- if not (contains "--enr-tcp-port=" (.Values.extraArgs | join ",")) }}
-    --enr-tcp-port={{ .Values.p2pPort }}
+    --enr-tcp-port={{ include "prysm.p2pPort" . }}
     {{- end }}
     {{- if not (contains "--enr-udp-port=" (.Values.extraArgs | join ",")) }}
-    --enr-udp-port={{ .Values.p2pPort }}
+    --enr-udp-port={{ include "prysm.p2pPort" . }}
     {{- end }}
   {{- end }}
     --listen-address=0.0.0.0
-    --port={{ .Values.p2pPort }}
-    --discovery-port={{ .Values.p2pPort }}
+    --port={{ include "prysm.p2pPort" . }}
+    --discovery-port={{ include "prysm.p2pPort" . }}
     --http
     --http-address=0.0.0.0
     --http-port={{ .Values.httpPort }}
@@ -118,7 +118,7 @@ defaultBootnodeCommandTemplate: |
     boot_node
     --datadir=/data
     --listen-address=0.0.0.0
-    --port={{ .Values.p2pPort }}
+    --port={{ include "prysm.p2pPort" . }}
   {{- range .Values.extraArgs }}
     {{ . }}
   {{- end }}
@@ -126,7 +126,7 @@ defaultBootnodeCommandTemplate: |
     --enr-port=$EXTERNAL_PORT
     $EXTERNAL_IP
   {{- else }}
-    --enr-port={{ .Values.p2pPort }}
+    --enr-port={{ include "prysm.p2pPort" . }}
     $(POD_IP)
   {{- end }}
 
@@ -140,13 +140,8 @@ customCommand: []
 p2pNodePort:
   # -- Expose P2P port via NodePort
   enabled: false
-  # -- Port used to start
-  startAt: 31000
-  # -- Overwrite a port for specific replicas
-  # @default -- See `values.yaml` for example
-  portsOverwrite: {}
-  #  "0": 32345
-  #  "3": 32348
+  # -- NodePort to be used
+  port: 31000
   initContainer:
     image:
       # -- Container image to fetch nodeport information

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -67,15 +67,15 @@ defaultBeaconCommandTemplate: |
     --enr-address=$(POD_IP)
     {{- end }}
     {{- if not (contains "--enr-tcp-port=" (.Values.extraArgs | join ",")) }}
-    --enr-tcp-port={{ include "prysm.p2pPort" . }}
+    --enr-tcp-port={{ include "lighthouse.p2pPort" . }}
     {{- end }}
     {{- if not (contains "--enr-udp-port=" (.Values.extraArgs | join ",")) }}
-    --enr-udp-port={{ include "prysm.p2pPort" . }}
+    --enr-udp-port={{ include "lighthouse.p2pPort" . }}
     {{- end }}
   {{- end }}
     --listen-address=0.0.0.0
-    --port={{ include "prysm.p2pPort" . }}
-    --discovery-port={{ include "prysm.p2pPort" . }}
+    --port={{ include "lighthouse.p2pPort" . }}
+    --discovery-port={{ include "lighthouse.p2pPort" . }}
     --http
     --http-address=0.0.0.0
     --http-port={{ .Values.httpPort }}
@@ -118,7 +118,7 @@ defaultBootnodeCommandTemplate: |
     boot_node
     --datadir=/data
     --listen-address=0.0.0.0
-    --port={{ include "prysm.p2pPort" . }}
+    --port={{ include "lighthouse.p2pPort" . }}
   {{- range .Values.extraArgs }}
     {{ . }}
   {{- end }}
@@ -126,7 +126,7 @@ defaultBootnodeCommandTemplate: |
     --enr-port=$EXTERNAL_PORT
     $EXTERNAL_IP
   {{- else }}
-    --enr-port={{ include "prysm.p2pPort" . }}
+    --enr-port={{ include "lighthouse.p2pPort" . }}
     $(POD_IP)
   {{- end }}
 

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -124,10 +124,10 @@ defaultBootnodeCommandTemplate: |
   {{- end }}
   {{- if .Values.p2pNodePort.enabled }}
     --enr-port=$EXTERNAL_PORT
-    $EXTERNAL_IP
+    --enr-address=$EXTERNAL_IP
   {{- else }}
     --enr-port={{ include "lighthouse.p2pPort" . }}
-    $(POD_IP)
+    --enr-address=$(POD_IP)
   {{- end }}
 
 

--- a/charts/lodestar/Chart.yaml
+++ b/charts/lodestar/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/ChainSafe/lodestar/master/assets/lodesta
 sources:
   - https://github.com/ChainSafe/lodestar
 type: application
-version: 1.0.6
+version: 1.1.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/lodestar/README.md
+++ b/charts/lodestar/README.md
@@ -1,7 +1,7 @@
 
 # lodestar
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Lodestar is a open-source TypeScript implementation of the Ethereum consensus engine.
 
@@ -55,8 +55,7 @@ Lodestar is a open-source TypeScript implementation of the Ethereum consensus en
 | p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
 | p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
-| p2pNodePort.portsOverwrite | object | See `values.yaml` for example | Overwrite a port for specific replicas |
-| p2pNodePort.startAt | int | `31000` | Port used to start |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
 | p2pPort | int | `9000` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
@@ -109,28 +108,20 @@ extraArgs:
   - --execution.urls=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 beacon nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
 
 ## Validator node targeting a beacon node service
 

--- a/charts/lodestar/README.md.gotmpl
+++ b/charts/lodestar/README.md.gotmpl
@@ -26,29 +26,20 @@ extraArgs:
   - --execution.urls=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 beacon nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
-
 
 ## Validator node targeting a beacon node service
 

--- a/charts/lodestar/templates/_helpers.tpl
+++ b/charts/lodestar/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "lodestar.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,9 +78,9 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "lodestar.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/lodestar/templates/_helpers.tpl
+++ b/charts/lodestar/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "lodestar.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "lodestar.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/lodestar/templates/_helpers.tpl
+++ b/charts/lodestar/templates/_helpers.tpl
@@ -68,3 +68,19 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- define "lodestar.clusterRoleName" -}}
 {{ .Release.Namespace }}-{{ include "lodestar.fullname" . }}
 {{- end }}
+
+{{- define "lodestar.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
+{{- print .Values.p2pPort }}
+{{- end }}
+{{- end -}}
+
+{{- define "lodestar.replicas" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end}}
+{{- end -}}

--- a/charts/lodestar/templates/service-headless.yaml
+++ b/charts/lodestar/templates/service-headless.yaml
@@ -8,11 +8,11 @@ spec:
   clusterIP: None
   ports:
   {{- if eq .Values.mode "beacon" }}
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "grandine.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "grandine.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/lodestar/templates/service-headless.yaml
+++ b/charts/lodestar/templates/service-headless.yaml
@@ -8,11 +8,11 @@ spec:
   clusterIP: None
   ports:
   {{- if eq .Values.mode "beacon" }}
-    - port: {{ include "grandine.p2pPort" . }}
+    - port: {{ include "lodestar.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ include "grandine.p2pPort" . }}
+    - port: {{ include "lodestar.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/lodestar/templates/service.p2p.nodeport.yaml
+++ b/charts/lodestar/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "lodestar.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "lodestar.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "lodestar.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "lodestar.p2pPort" $ }}
   selector:
     {{- include "lodestar.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "lodestar.fullname" $ }}-0"

--- a/charts/lodestar/templates/service.p2p.nodeport.yaml
+++ b/charts/lodestar/templates/service.p2p.nodeport.yaml
@@ -5,10 +5,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "lodestar.fullname" $ }}-p2p-{{ $i }}
+  name: {{ include "lodestar.fullname" $ }}-p2p-0
   labels:
     {{- include "lodestar.labels" $ | nindent 4 }}
-    pod: {{ include "lodestar.fullname" $ }}-{{ $i }}
+    pod: {{ include "lodestar.fullname" $ }}-0
     type: p2p
 spec:
   type: NodePort

--- a/charts/lodestar/templates/service.p2p.nodeport.yaml
+++ b/charts/lodestar/templates/service.p2p.nodeport.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.p2pNodePort.enabled -}}
-{{- if eq .Values.mode "beacon" }}
 
-{{- range $i, $e := until (int $.Values.replicas) }}
-
-{{- $port := add $.Values.p2pNodePort.startAt $i -}}
-{{- if hasKey $.Values.p2pNodePort.portsOverwrite ($i | toString) -}}
-  {{ $port = index $.Values.p2pNodePort.portsOverwrite ($i | toString) }}
-{{- end }}
+{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -21,20 +15,16 @@ spec:
   externalTrafficPolicy: Local
   ports:
     - name: p2p-tcp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "lodestar.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
       nodePort: {{ $port }}
     - name: p2p-udp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "lodestar.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
       nodePort: {{ $port }}
   selector:
     {{- include "lodestar.selectorLabels" $ | nindent 4 }}
-    statefulset.kubernetes.io/pod-name: {{ include "lodestar.fullname" $ }}-{{ $i }}
-
-{{- end }}
-
-{{- end }}
+    statefulset.kubernetes.io/pod-name: "{{ include "lodestar.fullname" $ }}-0"
 {{- end }}

--- a/charts/lodestar/templates/service.yaml
+++ b/charts/lodestar/templates/service.yaml
@@ -9,11 +9,11 @@ spec:
   type: ClusterIP
   ports:
   {{- if eq .Values.mode "beacon" }}
-    - port: {{ include "grandine.p2pPort" . }}
+    - port: {{ include "lodestar.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ include "grandine.p2pPort" . }}
+    - port: {{ include "lodestar.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/lodestar/templates/service.yaml
+++ b/charts/lodestar/templates/service.yaml
@@ -9,11 +9,11 @@ spec:
   type: ClusterIP
   ports:
   {{- if eq .Values.mode "beacon" }}
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "grandine.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "grandine.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/lodestar/templates/servicemonitor.yaml
+++ b/charts/lodestar/templates/servicemonitor.yaml
@@ -41,5 +41,5 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-{{- end}}
+{{- end }}
 {{- end }}

--- a/charts/lodestar/templates/statefulset.yaml
+++ b/charts/lodestar/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{ include "lodestar.replicas" . }}
   selector:
     matchLabels:
       {{- include "lodestar.selectorLabels" . | nindent 6 }}
@@ -119,10 +119,10 @@ spec:
           ports:
           {{- if eq .Values.mode "beacon" }}
             - name: p2p-tcp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "grandine.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "grandine.p2pPort" . }}
               protocol: UDP
             - name: http-api
               containerPort: {{ .Values.httpPort }}

--- a/charts/lodestar/templates/statefulset.yaml
+++ b/charts/lodestar/templates/statefulset.yaml
@@ -119,10 +119,10 @@ spec:
           ports:
           {{- if eq .Values.mode "beacon" }}
             - name: p2p-tcp
-              containerPort: {{ include "grandine.p2pPort" . }}
+              containerPort: {{ include "lodestar.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ include "grandine.p2pPort" . }}
+              containerPort: {{ include "lodestar.p2pPort" . }}
               protocol: UDP
             - name: http-api
               containerPort: {{ .Values.httpPort }}

--- a/charts/lodestar/values.yaml
+++ b/charts/lodestar/values.yaml
@@ -51,7 +51,7 @@ defaultBeaconCommandTemplate: |
     --dataDir=/data
     --discv5
     --listenAddress=0.0.0.0
-    --port={{ include "grandine.p2pPort" . }}
+    --port={{ include "lodestar.p2pPort" . }}
   {{- if .Values.p2pNodePort.enabled }}
     {{- if not (contains "--enr.ip=" (.Values.extraArgs | join ",")) }}
     --enr.ip=$EXTERNAL_IP
@@ -67,10 +67,10 @@ defaultBeaconCommandTemplate: |
     --enr.ip=$(POD_IP)
     {{- end }}
     {{- if not (contains "--enr.tcp=" (.Values.extraArgs | join ",")) }}
-    --enr.tcp={{ include "grandine.p2pPort" . }}
+    --enr.tcp={{ include "lodestar.p2pPort" . }}
     {{- end }}
     {{- if not (contains "--enr.udp=" (.Values.extraArgs | join ",")) }}
-    --enr.udp={{ include "grandine.p2pPort" . }}
+    --enr.udp={{ include "lodestar.p2pPort" . }}
     {{- end }}
   {{- end }}
     --rest

--- a/charts/lodestar/values.yaml
+++ b/charts/lodestar/values.yaml
@@ -51,7 +51,7 @@ defaultBeaconCommandTemplate: |
     --dataDir=/data
     --discv5
     --listenAddress=0.0.0.0
-    --port={{ .Values.p2pPort }}
+    --port={{ include "grandine.p2pPort" . }}
   {{- if .Values.p2pNodePort.enabled }}
     {{- if not (contains "--enr.ip=" (.Values.extraArgs | join ",")) }}
     --enr.ip=$EXTERNAL_IP
@@ -67,10 +67,10 @@ defaultBeaconCommandTemplate: |
     --enr.ip=$(POD_IP)
     {{- end }}
     {{- if not (contains "--enr.tcp=" (.Values.extraArgs | join ",")) }}
-    --enr.tcp={{ .Values.p2pPort }}
+    --enr.tcp={{ include "grandine.p2pPort" . }}
     {{- end }}
     {{- if not (contains "--enr.udp=" (.Values.extraArgs | join ",")) }}
-    --enr.udp={{ .Values.p2pPort }}
+    --enr.udp={{ include "grandine.p2pPort" . }}
     {{- end }}
   {{- end }}
     --rest
@@ -109,13 +109,8 @@ customCommand: []
 p2pNodePort:
   # -- Expose P2P port via NodePort
   enabled: false
-  # -- Port used to start
-  startAt: 31000
-  # -- Overwrite a port for specific replicas
-  # @default -- See `values.yaml` for example
-  portsOverwrite: {}
-  #  "0": 32345
-  #  "3": 32348
+  # -- NodePort to be used
+  port: 31000
   initContainer:
     image:
       # -- Container image to fetch nodeport information

--- a/charts/nethermind/Chart.yaml
+++ b/charts/nethermind/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://launchpad.ethereum.org/static/media/nethermind-circle.fbbf1a32.png
 sources:
   - https://github.com/NethermindEth/nethermind
 type: application
-version: 1.0.6
+version: 1.0.7
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/nethermind/README.md
+++ b/charts/nethermind/README.md
@@ -1,7 +1,7 @@
 
 # nethermind
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Nethermind is an Ethereum execution layer implementation created with the C# .NET tech stack, running on all major platforms including ARM.
 
@@ -57,6 +57,7 @@ Nethermind is an Ethereum execution layer implementation created with the C# .NE
 | p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
 | p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
+| p2pPort | int | `30303` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
 | persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |

--- a/charts/nethermind/templates/_helpers.tpl
+++ b/charts/nethermind/templates/_helpers.tpl
@@ -70,17 +70,17 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "nethermind.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
-{{- printf "30303" -}}
+{{- print .Values.p2pPort }}
 {{- end }}
 {{- end -}}
 
 {{- define "nethermind.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/nethermind/templates/_helpers.tpl
+++ b/charts/nethermind/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "nethermind.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "nethermind.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/nethermind/templates/service.p2p.nodeport.yaml
+++ b/charts/nethermind/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "nethermind.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "nethermind.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "nethermind.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "nethermind.p2pPort" $ }}
   selector:
     {{- include "nethermind.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "nethermind.fullname" $ }}-0"

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -142,6 +142,9 @@ readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 10
 
+# -- P2P Port
+p2pPort: 30303
+
 # -- HTTP Port
 httpPort: 8545
 

--- a/charts/nimbus/Chart.yaml
+++ b/charts/nimbus/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/nimbus-circle.2752d77b.png
 sources:
   - https://github.com/status-im/nimbus-eth2
 type: application
-version: 1.0.6
+version: 1.1.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/nimbus/README.md
+++ b/charts/nimbus/README.md
@@ -1,7 +1,7 @@
 
 # nimbus
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum consensus layer client, written in Java
 

--- a/charts/nimbus/templates/_helpers.tpl
+++ b/charts/nimbus/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "nimbus.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "nimbus.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/nimbus/templates/_helpers.tpl
+++ b/charts/nimbus/templates/_helpers.tpl
@@ -69,6 +69,14 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{ .Release.Namespace }}-{{ include "nimbus.fullname" . }}
 {{- end }}
 
+{{- define "nimbus.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
+{{- print .Values.p2pPort }}
+{{- end }}
+{{- end -}}
+
 {{- define "nimbus.replicas" -}}
 {{- if .Values.p2pNodePort.enabled }}
 {{- print 1 }}

--- a/charts/nimbus/templates/_helpers.tpl
+++ b/charts/nimbus/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "nimbus.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,9 +78,9 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "nimbus.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/nimbus/templates/service-headless.yaml
+++ b/charts/nimbus/templates/service-headless.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "nimbus.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "nimbus.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/nimbus/templates/service.p2p.nodeport.yaml
+++ b/charts/nimbus/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "nimbus.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "nimbus.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "nimbus.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "nimbus.p2pPort" $ }}
   selector:
     {{- include "nimbus.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "nimbus.fullname" $ }}-0"

--- a/charts/nimbus/templates/service.p2p.nodeport.yaml
+++ b/charts/nimbus/templates/service.p2p.nodeport.yaml
@@ -15,12 +15,12 @@ spec:
   externalTrafficPolicy: Local
   ports:
     - name: p2p-tcp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "nimbus.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
       nodePort: {{ $port }}
     - name: p2p-udp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "nimbus.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
       nodePort: {{ $port }}

--- a/charts/nimbus/templates/service.yaml
+++ b/charts/nimbus/templates/service.yaml
@@ -7,11 +7,11 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "nimbus.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "nimbus.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/nimbus/templates/statefulset.yaml
+++ b/charts/nimbus/templates/statefulset.yaml
@@ -113,10 +113,10 @@ spec:
               readOnly: true
           ports:
             - name: p2p-tcp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "nimbus.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "nimbus.p2pPort" . }}
               protocol: UDP
             - name: http-api
               containerPort: {{ .Values.httpPort }}

--- a/charts/nimbus/values.yaml
+++ b/charts/nimbus/values.yaml
@@ -63,10 +63,10 @@ defaultCommandTemplate: |
     --nat=extip:$(POD_IP)
     {{- end }}
     {{- if not (contains "--udp-port=" (.Values.extraArgs | join ",")) }}
-    --udp-port={{ .Values.p2pPort }}
+    --udp-port={{ include "nimbus.p2pPort" . }}
     {{- end }}
     {{- if not (contains "--tcp-port=" (.Values.extraArgs | join ",")) }}
-    --tcp-port={{ .Values.p2pPort }}
+    --tcp-port={{ include "nimbus.p2pPort" . }}
     {{- end }}
   {{- end }}
     --rest=true

--- a/charts/prysm/Chart.yaml
+++ b/charts/prysm/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/prysmatic-labs-circle.96c803fe
 sources:
   - https://github.com/prysmaticlabs/prysm
 type: application
-version: 1.0.5
+version: 1.1.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/prysm/README.md
+++ b/charts/prysm/README.md
@@ -1,7 +1,7 @@
 
 # prysm
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum 2.0 client, written in Go
 
@@ -55,8 +55,7 @@ An open-source Ethereum 2.0 client, written in Go
 | p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
 | p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
-| p2pNodePort.portsOverwrite | object | See `values.yaml` for example | Overwrite a port for specific replicas |
-| p2pNodePort.startAt | int | `31000` | Port used to start |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
 | p2pPort | int | `13000` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
@@ -110,28 +109,20 @@ extraArgs:
   - --execution-endpoint=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 beacon nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
 
 ## Validator node targeting a beacon node service
 

--- a/charts/prysm/README.md.gotmpl
+++ b/charts/prysm/README.md.gotmpl
@@ -26,29 +26,20 @@ extraArgs:
   - --execution-endpoint=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
-
-This would create 5 beacon nodes, exposed via Node Port services with the following configuration:
-- Node 0: `30000`
-- Node 1: `30001`
-- Node 2: `30002`
-- Node 3: `32000`
-- Node 4: `30004`
-
 
 ## Validator node targeting a beacon node service
 

--- a/charts/prysm/templates/_helpers.tpl
+++ b/charts/prysm/templates/_helpers.tpl
@@ -68,3 +68,19 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- define "prysm.clusterRoleName" -}}
 {{ .Release.Namespace }}-{{ include "prysm.fullname" . }}
 {{- end }}
+
+{{- define "prysm.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
+{{- print .Values.p2pPort }}
+{{- end }}
+{{- end -}}
+
+{{- define "prysm.replicas" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end}}
+{{- end -}}

--- a/charts/prysm/templates/_helpers.tpl
+++ b/charts/prysm/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "prysm.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "prysm.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/prysm/templates/_helpers.tpl
+++ b/charts/prysm/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "prysm.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,9 +78,9 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "prysm.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/prysm/templates/service-headless.yaml
+++ b/charts/prysm/templates/service-headless.yaml
@@ -8,11 +8,11 @@ spec:
   clusterIP: None
   ports:
   {{- if eq .Values.mode "beacon" }}
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "prysm.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "prysm.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/prysm/templates/service.p2p.nodeport.yaml
+++ b/charts/prysm/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "prysm.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "prysm.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "prysm.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "prysm.p2pPort" $ }}
   selector:
     {{- include "prysm.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "prysm.fullname" $ }}-0"

--- a/charts/prysm/templates/service.p2p.nodeport.yaml
+++ b/charts/prysm/templates/service.p2p.nodeport.yaml
@@ -5,10 +5,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "prysm.fullname" $ }}-p2p-{{ $i }}
+  name: {{ include "prysm.fullname" $ }}-p2p-0
   labels:
     {{- include "prysm.labels" $ | nindent 4 }}
-    pod: {{ include "prysm.fullname" $ }}-{{ $i }}
+    pod: {{ include "prysm.fullname" $ }}-0
     type: p2p
 spec:
   type: NodePort

--- a/charts/prysm/templates/service.p2p.nodeport.yaml
+++ b/charts/prysm/templates/service.p2p.nodeport.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.p2pNodePort.enabled -}}
-{{- if eq .Values.mode "beacon" }}
 
-{{- range $i, $e := until (int $.Values.replicas) }}
-
-{{- $port := add $.Values.p2pNodePort.startAt $i -}}
-{{- if hasKey $.Values.p2pNodePort.portsOverwrite ($i | toString) -}}
-  {{ $port = index $.Values.p2pNodePort.portsOverwrite ($i | toString) }}
-{{- end }}
+{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -21,20 +15,16 @@ spec:
   externalTrafficPolicy: Local
   ports:
     - name: p2p-tcp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "prysm.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
       nodePort: {{ $port }}
     - name: p2p-udp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "prysm.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
       nodePort: {{ $port }}
   selector:
     {{- include "prysm.selectorLabels" $ | nindent 4 }}
-    statefulset.kubernetes.io/pod-name: {{ include "prysm.fullname" $ }}-{{ $i }}
-
-{{- end }}
-
-{{- end }}
+    statefulset.kubernetes.io/pod-name: "{{ include "prysm.fullname" $ }}-0"
 {{- end }}

--- a/charts/prysm/templates/service.yaml
+++ b/charts/prysm/templates/service.yaml
@@ -8,11 +8,11 @@ spec:
   type: ClusterIP
   ports:
   {{- if eq .Values.mode "beacon" }}
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "prysm.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "prysm.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/prysm/templates/servicemonitor.yaml
+++ b/charts/prysm/templates/servicemonitor.yaml
@@ -41,5 +41,5 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-{{- end}}
+{{- end }}
 {{- end }}

--- a/charts/prysm/templates/statefulset.yaml
+++ b/charts/prysm/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{ include "prysm.replicas" . }}
   selector:
     matchLabels:
       {{- include "prysm.selectorLabels" . | nindent 6 }}
@@ -116,10 +116,10 @@ spec:
           ports:
           {{- if eq .Values.mode "beacon" }}
             - name: p2p-tcp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "prysm.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "prysm.p2pPort" . }}
               protocol: UDP
           {{- end }}
           {{- if or (eq .Values.mode "beacon") (eq .Values.mode "validator") }}

--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -73,10 +73,10 @@ defaultBeaconCommandTemplate: |
     --p2p-host-ip=$(POD_IP)
     {{- end }}
     {{- if not (contains "--p2p-tcp-port=" (.Values.extraArgs | join ",")) }}
-    --p2p-tcp-port={{ .Values.p2pPort }}
+    --p2p-tcp-port={{ include "prysm.p2pPort" . }}
     {{- end }}
     {{- if not (contains "--p2p-udp-port=" (.Values.extraArgs | join ",")) }}
-    --p2p-udp-port={{ .Values.p2pPort }}
+    --p2p-udp-port={{ include "prysm.p2pPort" . }}
     {{- end }}
   {{- end }}
     --rpc-host=0.0.0.0
@@ -118,13 +118,8 @@ customCommand: []
 p2pNodePort:
   # -- Expose P2P port via NodePort
   enabled: false
-  # -- Port used to start
-  startAt: 31000
-  # -- Overwrite a port for specific replicas
-  # @default -- See `values.yaml` for example
-  portsOverwrite: {}
-  #  "0": 32345
-  #  "3": 32348
+  # -- NodePort to be used
+  port: 31000
   initContainer:
     image:
       # -- Container image to fetch nodeport information

--- a/charts/reth/Chart.yaml
+++ b/charts/reth/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://github.com/paradigmxyz/reth/raw/main/assets/reth.jpg
 sources:
   - https://github.com/paradigmxyz/reth/
 type: application
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/reth/README.md
+++ b/charts/reth/README.md
@@ -1,7 +1,7 @@
 
 # reth
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implementation that is focused on being user-friendly, highly modular, as well as being fast and efficient. Reth is an Execution Layer (EL) and is compatible with all Ethereum Consensus Layer (CL) implementations that support the Engine API. It is originally built and driven forward by Paradigm, and is licensed under the Apache and MIT licenses.
 
@@ -57,6 +57,7 @@ Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implem
 | p2pNodePort.portForwardContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.portForwardContainer.image.repository | string | `"alpine/socat"` | Container image for the port forwarder |
 | p2pNodePort.portForwardContainer.image.tag | string | `"latest"` | Container tag |
+| p2pPort | int | `30303` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
 | persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |

--- a/charts/reth/templates/_helpers.tpl
+++ b/charts/reth/templates/_helpers.tpl
@@ -70,17 +70,17 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "reth.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
-{{- printf "30303" -}}
+{{- print .Values.p2pPort }}
 {{- end }}
 {{- end -}}
 
 {{- define "reth.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/reth/templates/_helpers.tpl
+++ b/charts/reth/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "reth.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "reth.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/reth/templates/service.p2p.nodeport.yaml
+++ b/charts/reth/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "reth.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "reth.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "reth.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "reth.p2pPort" $ }}
   selector:
     {{- include "reth.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "reth.fullname" $ }}-0"

--- a/charts/reth/values.yaml
+++ b/charts/reth/values.yaml
@@ -135,6 +135,9 @@ readinessProbe:
   initialDelaySeconds: 10
   periodSeconds: 10
 
+# -- P2P Port
+p2pPort: 30303
+
 # -- HTTP Port
 httpPort: 8545
 

--- a/charts/teku/Chart.yaml
+++ b/charts/teku/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/pegasys-teku-circle.4147bb69.p
 sources:
   - https://github.com/Consensys/teku/
 type: application
-version: 1.0.5
+version: 1.1.0
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/teku/README.md
+++ b/charts/teku/README.md
@@ -1,7 +1,7 @@
 
 # teku
 
-![Version: 1.0.5](https://img.shields.io/badge/Version-1.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum 2.0 client, written in Java
 
@@ -55,8 +55,7 @@ An open-source Ethereum 2.0 client, written in Java
 | p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
 | p2pNodePort.initContainer.image.tag | string | `"v1.21.3"` | Container tag |
-| p2pNodePort.portsOverwrite | object | See `values.yaml` for example | Overwrite a port for specific replicas |
-| p2pNodePort.startAt | int | `31000` | Port used to start |
+| p2pNodePort.port | int | `31000` | NodePort to be used |
 | p2pPort | int | `9000` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
@@ -109,20 +108,19 @@ extraArgs:
   - --ee-endpoint=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
 
 This would create 5 beacon nodes, exposed via Node Port services with the following configuration:

--- a/charts/teku/README.md.gotmpl
+++ b/charts/teku/README.md.gotmpl
@@ -26,20 +26,19 @@ extraArgs:
   - --ee-endpoint=<EXECUTION-ENDPOINT>
 ```
 
-## Beacon nodes exposing the P2P service via NodePort
+## Exposing the P2P service via NodePort
 
-This will make your nodes accessible via the Internet using services of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport). It will allocate a service definition and a pre-defined node port for each replica. The allocation starts at `p2pNodePort.startAt`. When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+This will make your node accessible via the Internet using a service of type [NodePort](https://kubernetes.io/docs/concepts/services-networking/service/#nodeport).
+When using `p2pNodePort.enabled` the exposed IP address on your ENR record will be the "External IP" of the node where the pod is running.
+
+**Limitations:** You can only run a single replica per chart deployment when using `p2pNodePort.enabled=true`.If you need N nodes, simply deploy the chart N times.
 
 ```yaml
-replicas: 5
-
-mode: "beacon"
+replicas: 1
 
 p2pNodePort:
   enabled: true
-  startAt: 30000
-  portsOverwrite:
-    "3": 32000
+  port: 31000
 ```
 
 This would create 5 beacon nodes, exposed via Node Port services with the following configuration:

--- a/charts/teku/templates/_helpers.tpl
+++ b/charts/teku/templates/_helpers.tpl
@@ -68,3 +68,19 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- define "teku.clusterRoleName" -}}
 {{ .Release.Namespace }}-{{ include "teku.fullname" . }}
 {{- end }}
+
+{{- define "teku.p2pPort" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print .Values.p2pNodePort.port }}
+{{- else }}
+{{- print .Values.p2pPort }}
+{{- end }}
+{{- end -}}
+
+{{- define "teku.replicas" -}}
+{{- if .Values.p2pNodePort.enabled }}
+{{- print 1 }}
+{{ else }}
+{{- print .Values.replicas }}
+{{- end}}
+{{- end -}}

--- a/charts/teku/templates/_helpers.tpl
+++ b/charts/teku/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "teku.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,9 +78,9 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "teku.replicas" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}
-{{- end}}
+{{- end }}
 {{- end -}}

--- a/charts/teku/templates/_helpers.tpl
+++ b/charts/teku/templates/_helpers.tpl
@@ -70,7 +70,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end }}
 
 {{- define "teku.p2pPort" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}
@@ -78,7 +78,7 @@ It needs to be namespace prefixed to avoid naming conflicts when using the same 
 {{- end -}}
 
 {{- define "teku.replicas" -}}
-{{- if and (.Values.p2pNodePort.enabled) ( gt .Values.replicas  1) }}
+{{- if and (.Values.p2pNodePort.enabled) (gt (int .Values.replicas)  1) }}
 {{- print 1 }}
 {{ else }}
 {{- print .Values.replicas }}

--- a/charts/teku/templates/service-headless.yaml
+++ b/charts/teku/templates/service-headless.yaml
@@ -8,11 +8,11 @@ spec:
   clusterIP: None
   ports:
   {{- if eq .Values.mode "beacon" }}
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "teku.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "teku.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/teku/templates/service.p2p.nodeport.yaml
+++ b/charts/teku/templates/service.p2p.nodeport.yaml
@@ -1,6 +1,4 @@
 {{- if .Values.p2pNodePort.enabled -}}
-
-{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -18,12 +16,12 @@ spec:
       port: {{ include "teku.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ $port }}
+      nodePort: {{ include "teku.p2pPort" $ }}
     - name: p2p-udp
       port: {{ include "teku.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ $port }}
+      nodePort: {{ include "teku.p2pPort" $ }}
   selector:
     {{- include "teku.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "teku.fullname" $ }}-0"

--- a/charts/teku/templates/service.p2p.nodeport.yaml
+++ b/charts/teku/templates/service.p2p.nodeport.yaml
@@ -5,10 +5,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "teku.fullname" $ }}-p2p-{{ $i }}
+  name: {{ include "teku.fullname" $ }}-p2p-0
   labels:
     {{- include "teku.labels" $ | nindent 4 }}
-    pod: {{ include "teku.fullname" $ }}-{{ $i }}
+    pod: {{ include "teku.fullname" $ }}-0
     type: p2p
 spec:
   type: NodePort

--- a/charts/teku/templates/service.p2p.nodeport.yaml
+++ b/charts/teku/templates/service.p2p.nodeport.yaml
@@ -1,12 +1,6 @@
 {{- if .Values.p2pNodePort.enabled -}}
-{{- if eq .Values.mode "beacon" }}
 
-{{- range $i, $e := until (int $.Values.replicas) }}
-
-{{- $port := add $.Values.p2pNodePort.startAt $i -}}
-{{- if hasKey $.Values.p2pNodePort.portsOverwrite ($i | toString) -}}
-  {{ $port = index $.Values.p2pNodePort.portsOverwrite ($i | toString) }}
-{{- end }}
+{{- $port := $.Values.p2pNodePort.port -}}
 ---
 apiVersion: v1
 kind: Service
@@ -21,20 +15,16 @@ spec:
   externalTrafficPolicy: Local
   ports:
     - name: p2p-tcp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "teku.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
       nodePort: {{ $port }}
     - name: p2p-udp
-      port: {{ $.Values.p2pPort }}
+      port: {{ include "teku.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
       nodePort: {{ $port }}
   selector:
     {{- include "teku.selectorLabels" $ | nindent 4 }}
-    statefulset.kubernetes.io/pod-name: {{ include "teku.fullname" $ }}-{{ $i }}
-
-{{- end }}
-
-{{- end }}
+    statefulset.kubernetes.io/pod-name: "{{ include "teku.fullname" $ }}-0"
 {{- end }}

--- a/charts/teku/templates/service.yaml
+++ b/charts/teku/templates/service.yaml
@@ -8,11 +8,11 @@ spec:
   type: ClusterIP
   ports:
   {{- if eq .Values.mode "beacon" }}
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "teku.p2pPort" . }}
       targetPort: p2p-tcp
       protocol: TCP
       name: p2p-tcp
-    - port: {{ .Values.p2pPort }}
+    - port: {{ include "teku.p2pPort" . }}
       targetPort: p2p-udp
       protocol: UDP
       name: p2p-udp

--- a/charts/teku/templates/servicemonitor.yaml
+++ b/charts/teku/templates/servicemonitor.yaml
@@ -41,5 +41,5 @@ spec:
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}
-{{- end}}
+{{- end }}
 {{- end }}

--- a/charts/teku/templates/statefulset.yaml
+++ b/charts/teku/templates/statefulset.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- toYaml .Values.annotations | nindent 4 }}
 spec:
   podManagementPolicy: {{ .Values.podManagementPolicy }}
-  replicas: {{ .Values.replicas }}
+  replicas: {{ include "teku.replicas" . }}
   selector:
     matchLabels:
       {{- include "teku.selectorLabels" . | nindent 6 }}
@@ -116,10 +116,10 @@ spec:
           ports:
           {{- if eq .Values.mode "beacon" }}
             - name: p2p-tcp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "teku.p2pPort" . }}
               protocol: TCP
             - name: p2p-udp
-              containerPort: {{ .Values.p2pPort }}
+              containerPort: {{ include "teku.p2pPort" . }}
               protocol: UDP
           {{- end }}
           {{- if or (eq .Values.mode "beacon") (eq .Values.mode "validator") }}

--- a/charts/teku/values.yaml
+++ b/charts/teku/values.yaml
@@ -49,7 +49,7 @@ defaultBeaconCommandTemplate: |
     --log-destination=CONSOLE
     --data-path=/data
     --p2p-enabled=true
-    --p2p-port={{ .Values.p2pPort }}
+    --p2p-port={{ include "teku.p2pPort" . }}
   {{- if .Values.p2pNodePort.enabled }}
     {{- if not (contains "--p2p-advertised-ip=" (.Values.extraArgs | join ",")) }}
     --p2p-advertised-ip=$EXTERNAL_IP
@@ -62,7 +62,7 @@ defaultBeaconCommandTemplate: |
     --p2p-advertised-ip=$(POD_IP)
     {{- end }}
     {{- if not (contains "--p2p-advertised-port=" (.Values.extraArgs | join ",")) }}
-    --p2p-advertised-port={{ .Values.p2pPort }}
+    --p2p-advertised-port={{ include "teku.p2pPort" . }}
     {{- end }}
   {{- end }}
     --rest-api-enabled=true
@@ -107,13 +107,8 @@ customCommand: []
 p2pNodePort:
   # -- Expose P2P port via NodePort
   enabled: false
-  # -- Port used to start
-  startAt: 31000
-  # -- Overwrite a port for specific replicas
-  # @default -- See `values.yaml` for example
-  portsOverwrite: {}
-  #  "0": 32345
-  #  "3": 32348
+  # -- NodePort to be used
+  port: 31000
   initContainer:
     image:
       # -- Container image to fetch nodeport information


### PR DESCRIPTION
## Context

Some charts (prysm, lodestar, lighthouse, grandine, teku) that support announcing a different p2p port in their ENRs have the following way of configuring nodePort in the values file:

```yaml
p2pNodePort:
  # -- Expose P2P port via NodePort
  enabled: false
  # -- Port used to start
  startAt: 31000
```

The reasoning for this back then was that you could use the same chart deployment to run many replicas. 

Note: Actually.... prysm shouldn't have this, because they don't allow you to announce a different port then the one that the process is using. So the NodePort logic there is broken atm and it's not forwarding it correctly to the Pod port. 

Other charts (besu, erigon, ethereumjs, geth, nethermind, nimbus, reth)  where the clients don't allow you to announce a different port,  have:

```yaml
p2pNodePort:
  # -- Expose P2P port via NodePort
  enabled: false
  # -- Port used to start
  port: 31000
```
This only make sense when the replica is set to 1.

---

## Change

This PR makes it consistent across all charts so that we just use the 2nd version:


```yaml
p2pNodePort:
  # -- Expose P2P port via NodePort
  enabled: false
  # -- Port used to start
  port: 31000
```

It makes it more consistent across all charts and forces a deployment to have max 1 replica when using nodePort. Also fixes that problem that was detected with prysm. 