### PR TITLE
fix: make-lint uses git safe directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ init:
 	@pre-commit install
 
 lint:
-	@docker run --rm --workdir /workdir --volume "$(CURRENT_DIR):/workdir" quay.io/helmpack/chart-testing:v3.9.0 ct lint --target-branch master
+	@docker run --rm --workdir /workdir --volume "$(CURRENT_DIR):/workdir" quay.io/helmpack/chart-testing:v3.9.0 /bin/sh -c "git config --global --add safe.directory /workdir; ct lint --target-branch master"
 
 docs:
 	@docker run --rm --volume "$(CURRENT_DIR):/helm-docs" -u $(UID) jnorwood/helm-docs:v1.5.0


### PR DESCRIPTION
Closes #238 

The issue only presents itself in Windows & WSL environments - the `is not a git repository` message is confusing, but if you exec into the container and run a `git status` you'll see a more verbose error:

```sh
fatal: detected dubious ownership in repository at '/workdir'
To add an exception for this directory, call:

        git config --global --add safe.directory /workdir
```

Some [additional documentation](https://github.blog/2022-04-18-highlights-from-git-2-36/#stricter-repository-ownership-checks) about the error.

Fixed by using the `--add safe.directory` cmd