### PR TITLE
Increase `inMemoryEpochs` setting in dora config

### DIFF
--- a/charts/dora/Chart.yaml
+++ b/charts/dora/Chart.yaml
@@ -3,7 +3,7 @@ name: dora
 description: A Beaconchain explorer is a tool that allows users to view and interact with the data on the Ethereum Beacon Chain. It is similar to a blockchain explorer, which allows users to view data on a blockchain such as the current state of transactions and blocks - but focussed on exploring the beaconchain.
 home: https://github.com/pk910/dora
 type: application
-version: 0.0.1
+version: 0.0.2
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/dora/README.md
+++ b/charts/dora/README.md
@@ -1,7 +1,7 @@
 
 # dora
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Beaconchain explorer is a tool that allows users to view and interact with the data on the Ethereum Beacon Chain. It is similar to a blockchain explorer, which allows users to view data on a blockchain such as the current state of transactions and blocks - but focussed on exploring the beaconchain.
 

--- a/charts/dora/values.yaml
+++ b/charts/dora/values.yaml
@@ -112,7 +112,7 @@ config: |
     # indexer keeps track of the latest epochs in memory.
     indexer:
       # max number of epochs to keep in memory
-      inMemoryEpochs: 3
+      inMemoryEpochs: 6
 
       # disable synchronizing and everything that writes to the db (indexer just maintains local cache)
       disableIndexWriter: false


### PR DESCRIPTION
The low `inMemoryEpochs` causes unneeded synchronizations in normal running networks, 
because blocks are evicted from memory before being finalized.

This is not breaking the explorer,  but causes some unwanted side effects that can currently be seen on the sepolia instance, which drops cached blocks before they're finalized-processed:
https://dora.sepolia.ethpandaops.io/epochs 
The synchronizer in the sepolia instance is still far behind, which makes the issue more visible