### PR TITLE
fix(reth): log.file.directory flag

### DIFF
--- a/charts/ethereum-node/Chart.lock
+++ b/charts/ethereum-node/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.0.9
 - name: reth
   repository: file://../reth
-  version: 0.0.9
+  version: 0.0.10
 - name: grandine
   repository: file://../grandine
   version: 0.1.1
@@ -40,6 +40,6 @@ dependencies:
   version: 0.1.4
 - name: xatu-sentry
   repository: file://../xatu-sentry
-  version: 0.0.7
-digest: sha256:0426637d7b196b7b9b09fcc3d7cf260dcaa1e63c6ea6e1002ff6c498d44370c9
-generated: "2023-09-29T16:34:32.642441+02:00"
+  version: 0.0.8
+digest: sha256:4b6b12c92e7b599a55c7a2597c5e0f8a28568b4f5c88f0ff1f33e98a339a6561
+generated: "2023-11-24T16:37:16.587713617+01:00"

--- a/charts/ethereum-node/Chart.yaml
+++ b/charts/ethereum-node/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/6250754?s=200&v=4
 sources:
   - https://github.com/ethpandaops/ethereum-helm-charts
 type: application
-version: 0.0.16
+version: 0.0.17
 maintainers:
   - name: skylenet
     email: rafael@skyle.net
@@ -40,7 +40,7 @@ dependencies:
   repository: "file://../nethermind"
   condition: nethermind.enabled
 - name: reth
-  version: "0.0.9"
+  version: "0.0.10"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../reth"
   condition: reth.enabled
@@ -82,7 +82,7 @@ dependencies:
   repository: "file://../ethereum-metrics-exporter"
   condition: ethereum-metrics-exporter.enabled
 - name: xatu-sentry
-  version: "0.0.7"
+  version: "0.0.8"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../xatu-sentry"
   condition: xatu-sentry.enabled

--- a/charts/ethereum-node/README.md
+++ b/charts/ethereum-node/README.md
@@ -25,9 +25,9 @@ This chart acts as an umbrella chart and allows to run a ethereum execution and 
 | file://../nethermind | nethermind | 1.0.9 |
 | file://../nimbus | nimbus | 1.1.1 |
 | file://../prysm | prysm | 1.1.1 |
-| file://../reth | reth | 0.0.9 |
+| file://../reth | reth | 0.0.10 |
 | file://../teku | teku | 1.1.1 |
-| file://../xatu-sentry | xatu-sentry | 0.0.7 |
+| file://../xatu-sentry | xatu-sentry | 0.0.8 |
 
 # Details
 

--- a/charts/reth/Chart.yaml
+++ b/charts/reth/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://github.com/paradigmxyz/reth/raw/main/assets/reth.jpg
 sources:
   - https://github.com/paradigmxyz/reth/
 type: application
-version: 0.0.9
+version: 0.0.10
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/reth/README.md
+++ b/charts/reth/README.md
@@ -1,7 +1,7 @@
 
 # reth
 
-![Version: 0.0.9](https://img.shields.io/badge/Version-0.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.10](https://img.shields.io/badge/Version-0.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implementation that is focused on being user-friendly, highly modular, as well as being fast and efficient. Reth is an Execution Layer (EL) and is compatible with all Ethereum Consensus Layer (CL) implementations that support the Engine API. It is originally built and driven forward by Paradigm, and is licensed under the Apache and MIT licenses.
 

--- a/charts/reth/values.yaml
+++ b/charts/reth/values.yaml
@@ -61,7 +61,7 @@ defaultCommandTemplate: |
     --authrpc.jwtsecret=/data/jwt.hex
     --authrpc.addr=0.0.0.0
     --authrpc.port={{ .Values.authPort }}
-    --log.directory=/data/logs
+    --log.file.directory=/data/logs
   {{- if .Values.metricsPort }}
     --metrics={{ .Values.metricsPort }}
   {{- end }}


### PR DESCRIPTION
Closes #254 

- fix: use reth's flag `--log.file.directory` instead of the incorrect `--log.directory`
- fix: bump xatu-sentry to `0.0.8` in ethereum-node chart