### PR TITLE
fixes dshackle readiness and liveness probe overrides; when attemptin…

### DIFF
--- a/charts/dshackle/Chart.yaml
+++ b/charts/dshackle/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/49622339?s=200&v=4
 sources:
   - https://github.com/emeraldpay/dshackle
 type: application
-version: 0.1.7
+version: 0.1.8
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/dshackle/templates/statefulset.yaml
+++ b/charts/dshackle/templates/statefulset.yaml
@@ -79,9 +79,25 @@ spec:
               containerPort: {{ .Values.healthPort }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- if .Values.livenessProbe.httpGet }}
+            httpGet:
+              {{- toYaml .Values.livenessProbe.httpGet | nindent 14 }}
+            {{- else if .Values.livenessProbe.tcpSocket }}
+            tcpSocket:
+              {{- toYaml .Values.livenessProbe.tcpSocket | nindent 14 }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- if .Values.readinessProbe.httpGet }}
+            httpGet:
+              {{- toYaml .Values.readinessProbe.httpGet | nindent 14 }}
+            {{- else if .Values.readinessProbe.tcpSocket }}
+            tcpSocket:
+              {{- toYaml .Values.readinessProbe.tcpSocket | nindent 14 }}
+            {{- end }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:


### PR DESCRIPTION
Hello

This change will allow users to set `httpGet` readiness/liveness probes. The default values.yaml causes the `tcpSocket` to be set in the resulting yaml even if `tcpSocket` is set to `null`.

Dshackle presents a `health` configuration which allows users to set a minimum-available upstream threshold before returning non-200 for requests to the health probe.

The health endpoint could also be enabled by default, however, this is the least impactful to anyone currently relying on simple tcpSocket probes, who have not configured dshackle to enable the health endpoint.

To reproduce the issue, use this `override.yaml`:

```
livenessProbe:
  httpGet:
    path: /health?detailed
    port: 1234
readinessProbe:
  httpGet:
    path: /health?detailed
    port: 1234
```

broken
```
$ helm template dshackle -f override.yaml . | grep -5 /health?detailed
            - name: health
              containerPort: 8082
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /health?detailed
              port: 1234
            initialDelaySeconds: 60
            periodSeconds: 30
            tcpSocket:
              port: http
          readinessProbe:
            httpGet:
              path: /health?detailed
              port: 1234
            initialDelaySeconds: 10
            periodSeconds: 10
            tcpSocket:
              port: http
```

fixed:
```
$ helm template dshackle -f override.yaml . | grep -5 /health?detailed
            - name: health
              containerPort: 8082
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /health?detailed
              port: 1234
            initialDelaySeconds: 60
            periodSeconds: 30
          readinessProbe:
            httpGet:
              path: /health?detailed
              port: 1234
            initialDelaySeconds: 10
            periodSeconds: 10
          resources:
```

The specific error from the sts controller is 

```
create Pod dshackle-0 in StatefulSet dshackle failed error: Pod "dshackle-0" is invalid: [spec.containers[0].livenessProbe.tcpSocket: Forbidden: may not specify more than 1 handler type, spec.containers[0].readinessProbe.tcpSocket: Forbidden: may not specify more than 1 handler type]
```

 