### PR TITLE
[prysm]: /bin/bash as command template

### DIFF
--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -9,11 +9,11 @@ replicas: 1
 
 image:
   # -- Prysm container image repository
+  # Multi-Arch (arm64/amd64) image
+  #repository: gcr.io/prylabs-dev/prysm/beacon-chain
+  # Official image
   #repository: gcr.io/prysmaticlabs/prysm/beacon-chain
   repository: ethpandaops/prysm
-  # Note: The official beacon-chain image from prysmaticlabs doesn't contain any shell (`sh`)
-  #       which is required to detect the NodePorts when using `p2pNodePort.enabled=true`. See
-  #       the following example on how to create your own: https://github.com/skylenet/prysm-debian-docker/blob/master/Dockerfile
   # When using a validator:
   # repository: gcr.io/prysmaticlabs/prysm/validator
   # -- Prysm container image tag
@@ -49,7 +49,7 @@ checkpointSync:
 # -- Template used for the default beacon command
 # @default -- See `values.yaml`
 defaultBeaconCommandTemplate: |
-  - sh
+  - /bin/bash
   - -ac
   - >
   {{- if .Values.p2pNodePort.enabled }}


### PR DESCRIPTION
Prysm images include /bin/bash, but not /bin/sh