### PR TITLE
Add exec to reth command

### DIFF
--- a/charts/ethereum-node/Chart.lock
+++ b/charts/ethereum-node/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 1.0.9
 - name: reth
   repository: file://../reth
-  version: 0.0.11
+  version: 0.0.12
 - name: grandine
   repository: file://../grandine
   version: 0.1.1

--- a/charts/ethereum-node/Chart.yaml
+++ b/charts/ethereum-node/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/6250754?s=200&v=4
 sources:
   - https://github.com/ethpandaops/ethereum-helm-charts
 type: application
-version: 0.0.19
+version: 0.0.20
 maintainers:
   - name: skylenet
     email: rafael@skyle.net
@@ -40,7 +40,7 @@ dependencies:
   repository: "file://../nethermind"
   condition: nethermind.enabled
 - name: reth
-  version: "0.0.11"
+  version: "0.0.12"
   #repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   repository: "file://../reth"
   condition: reth.enabled

--- a/charts/ethereum-node/README.md
+++ b/charts/ethereum-node/README.md
@@ -1,7 +1,7 @@
 
 # ethereum-node
 
-![Version: 0.0.19](https://img.shields.io/badge/Version-0.0.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.20](https://img.shields.io/badge/Version-0.0.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This chart acts as an umbrella chart and allows to run a ethereum execution and consensus layer client. It's also able to deploy optional monitoring applications.
 
@@ -25,7 +25,7 @@ This chart acts as an umbrella chart and allows to run a ethereum execution and 
 | file://../nethermind | nethermind | 1.0.9 |
 | file://../nimbus | nimbus | 1.1.1 |
 | file://../prysm | prysm | 1.1.1 |
-| file://../reth | reth | 0.0.11 |
+| file://../reth | reth | 0.0.12 |
 | file://../teku | teku | 1.1.1 |
 | file://../xatu-sentry | xatu-sentry | 0.0.8 |
 

--- a/charts/reth/Chart.yaml
+++ b/charts/reth/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://github.com/paradigmxyz/reth/raw/main/assets/reth.jpg
 sources:
   - https://github.com/paradigmxyz/reth/
 type: application
-version: 0.0.11
+version: 0.0.12
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/reth/README.md
+++ b/charts/reth/README.md
@@ -1,7 +1,7 @@
 
 # reth
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implementation that is focused on being user-friendly, highly modular, as well as being fast and efficient. Reth is an Execution Layer (EL) and is compatible with all Ethereum Consensus Layer (CL) implementations that support the Engine API. It is originally built and driven forward by Paradigm, and is licensed under the Apache and MIT licenses.
 

--- a/charts/reth/values.yaml
+++ b/charts/reth/values.yaml
@@ -31,7 +31,7 @@ defaultCommandTemplate: |
   {{- if .Values.p2pNodePort.enabled }}
     . /env/init-nodeport;
   {{- end }}
-    /usr/local/bin/reth node
+    exec /usr/local/bin/reth node
     --datadir=/data
     --config=/data/config.toml
   {{- if .Values.p2pNodePort.enabled }}


### PR DESCRIPTION
Without `exec` the shell spawns a new child process to run the command. So then when we send the container a kill signal, for example when rolling out a new deployment, `reth` process doesn't get this signal. So then Pod just sits in "Terminating" until timed out.