### PR TITLE
fix make lint 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ init:
 	@pre-commit install
 
 lint:
-	@docker run --rm --workdir /workdir --volume "$(CURRENT_DIR):/workdir" -u $(UID) -e "HOME=/tmp" quay.io/helmpack/chart-testing:v3.10.0 ct lint --target-branch master
+	@docker run --userns=host --rm --workdir /workdir --volume "$(CURRENT_DIR):/workdir" -u $(UID) -e "HOME=/tmp" quay.io/helmpack/chart-testing:v3.10.0 sh -ac 'chown ${UID} .; exec ct lint --target-branch master'
 
 docs:
 	@docker run --rm --volume "$(CURRENT_DIR):/helm-docs" -u $(UID) jnorwood/helm-docs:v1.5.0

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ init:
 	@pre-commit install
 
 lint:
-	@docker run --userns=host --rm --workdir /workdir --volume "$(CURRENT_DIR):/workdir" -u $(UID) -e "HOME=/tmp" quay.io/helmpack/chart-testing:v3.10.0 sh -ac 'chown ${UID} .; exec ct lint --target-branch master'
+	@docker run --rm --workdir /workdir --volume "$(CURRENT_DIR):/workdir" -u $(UID) -e "HOME=/tmp" quay.io/helmpack/chart-testing:v3.10.0 sh -ac 'chown ${UID} .; exec ct lint --target-branch master'
 
 docs:
 	@docker run --rm --volume "$(CURRENT_DIR):/helm-docs" -u $(UID) jnorwood/helm-docs:v1.5.0


### PR DESCRIPTION
Linting was failing due to: 

```
Error: failed linting charts: failed identifying charts to process: must be in a git repository
make: *** [lint] Error 1
````

So... git was complaining again suddenly about:

```
fatal: detected dubious ownership in repository at '/workdir'
```

Which indicates some problem with file permissions on the directory.

Checking the dir inside the container shows that indeed the bind mount is owned by "root":

```sh
7f95bad9358c:/workdir$ ls -la .
total 36
drwxr-xr-x   12 root     root           384 Dec 19 11:58 .
drwxr-xr-x    1 root     root          4096 Dec 19 12:04 ..
drwxr-xr-x   13 501      root           416 Dec 19 12:02 .git
drwxr-xr-x    4 501      root           128 Dec 19 11:58 .github
-rw-r--r--    1 501      root           147 Dec 19 11:58 .gitignore
-rw-r--r--    1 501      root           457 Dec 19 11:58 .pre-commit-config.yaml
-rw-r--r--    1 501      root          1070 Dec 19 11:58 LICENSE
-rw-r--r--    1 501      root           458 Dec 19 12:02 Makefile
-rw-r--r--    1 501      root          6909 Dec 19 11:58 README.md
drwxr-xr-x   53 501      root          1696 Dec 19 11:58 charts
-rw-r--r--    1 501      root           400 Dec 19 11:58 ct.yaml
-rw-r--r--    1 501      root          1034 Dec 19 11:58 lintconf.yaml
```

Which is weird. I suspect is has something to do with https://docs.docker.com/engine/security/userns-remap/ . Because the user is allowed to write into the dir, even though it belongs to "root". As a workaround, to stop git from complaining, I've just manually added a chown to the current user and then everything starts working again. 