### PR TITLE
Update k8s-kubectl image

### DIFF
--- a/charts/armiarma/values.yaml
+++ b/charts/armiarma/values.yaml
@@ -52,7 +52,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/besu/values.yaml
+++ b/charts/besu/values.yaml
@@ -84,7 +84,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
   portForwardContainer:

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -109,7 +109,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
   portForwardContainer:

--- a/charts/ethereumjs/values.yaml
+++ b/charts/ethereumjs/values.yaml
@@ -85,7 +85,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
   portForwardContainer:

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -92,7 +92,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
   portForwardContainer:

--- a/charts/grandine/values.yaml
+++ b/charts/grandine/values.yaml
@@ -91,7 +91,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/ipfs-cluster/values.yaml
+++ b/charts/ipfs-cluster/values.yaml
@@ -12,7 +12,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -147,7 +147,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/lodestar/values.yaml
+++ b/charts/lodestar/values.yaml
@@ -119,7 +119,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -88,7 +88,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
   portForwardContainer:

--- a/charts/nimbus/values.yaml
+++ b/charts/nimbus/values.yaml
@@ -100,7 +100,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
   portForwardContainer:

--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -125,7 +125,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
 

--- a/charts/reth/values.yaml
+++ b/charts/reth/values.yaml
@@ -85,7 +85,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
   portForwardContainer:

--- a/charts/teku/values.yaml
+++ b/charts/teku/values.yaml
@@ -116,7 +116,7 @@ p2pNodePort:
       # -- Container image to fetch nodeport information
       repository: lachlanevenson/k8s-kubectl
       # -- Container tag
-      tag: v1.21.3
+      tag: v1.25.4
       # -- Container pull policy
       pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The `arm64` image for `k8s-kubectl:v1.21.3` is broken:

```
$ docker run --entrypoint=/bin/sh --rm -ti lachlanevenson/k8s-kubectl:v1.21.3 
~ # cat `which kubectl`
<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/v1.21.3/bin/linux/aarch64/kubectl</Details></Error>~ # 
```

The issue is fixed in `v1.25.4`:

```
$ docker run --entrypoint=/bin/sh --rm -ti lachlanevenson/k8s-kubectl:v1.25.4
~ # kubectl version
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
Client Version: version.Info{Major:"1", Minor:"25", GitVersion:"v1.25.4", GitCommit:"872a965c6c6526caa949f0c6ac028ef7aff3fb78", GitTreeState:"clean", BuildDate:"2022-11-09T13:36:36Z", GoVersion:"go1.19.3", Compiler:"gc", Platform:"linux/arm64"}
Kustomize Version: v4.5.7
```

This PR sets `v1.25.4` as the default in all `values.yaml` files.