### PR TITLE
Fix `service.type: LoadBalancer`

### DIFF
--- a/charts/dshackle/Chart.yaml
+++ b/charts/dshackle/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://avatars.githubusercontent.com/u/49622339?s=200&v=4
 sources:
   - https://github.com/emeraldpay/dshackle
 type: application
-version: 0.1.7
+version: 0.1.8
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/dshackle/templates/_helpers.tpl
+++ b/charts/dshackle/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+HTTP port
+*/}}
+{{- define "dshackle.httpPort" -}}
+{{- default 8545 .Values.httpPort }}
+{{- end }}

--- a/charts/dshackle/templates/service.yaml
+++ b/charts/dshackle/templates/service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "dshackle.fullname" . }}
   labels:
     {{- include "dshackle.labels" . | nindent 4 }}
+  annotations:
+    {{ toYaml .Values.service.annotations | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/dshackle/values.yaml
+++ b/charts/dshackle/values.yaml
@@ -95,6 +95,8 @@ ingress:
 service:
   # -- Service type
   type: ClusterIP
+  # -- Annotations for the Service
+  annotations: {}
 
 # -- Affinity configuration for pods
 affinity: {}


### PR DESCRIPTION
Changes to `dshackle` Helm chart to fix functionality when `service.type: LoadBalancer`:
- Adding missing `dshackle.httpPort` to template
- Adding `annotations` to Service