### PR TITLE
chart releaser: bump version to support 'skip_existing'

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           helm repo add ethpandaops https://ethpandaops.github.io/ethereum-helm-charts
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.6.0
         with:
           charts_dir: charts
           skip_existing: true


### PR DESCRIPTION
I've added directly `skip_existing: true` when trying to fix the recent release, it turns out it was just added in v.1.6.0 of that action. So I'm updating it. 