### PR TITLE
ethereum-address-metrics-exporter: raise ServiceMonitor interval

### DIFF
--- a/charts/ethereum-address-metrics-exporter/Chart.yaml
+++ b/charts/ethereum-address-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: ethereum-address-metrics-exporter
 description: A prometheus exporter for Ethereum externally owned account and contract addresses
 home: https://github.com/ethpandaops/ethereum-address-metrics-exporter
 type: application
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: savid
     email: andrew.davis@ethereum.org

--- a/charts/ethereum-address-metrics-exporter/README.md
+++ b/charts/ethereum-address-metrics-exporter/README.md
@@ -1,7 +1,7 @@
 
 # ethereum-address-metrics-exporter
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A prometheus exporter for Ethereum externally owned account and contract addresses
 

--- a/charts/ethereum-address-metrics-exporter/README.md
+++ b/charts/ethereum-address-metrics-exporter/README.md
@@ -55,7 +55,7 @@ A prometheus exporter for Ethereum externally owned account and contract address
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.annotations | object | `{}` | Additional ServiceMonitor annotations |
 | serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator https://github.com/coreos/prometheus-operator |
-| serviceMonitor.interval | string | `"15s"` | ServiceMonitor scrape interval |
+| serviceMonitor.interval | string | `"1m"` | ServiceMonitor scrape interval |
 | serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor |
 | serviceMonitor.path | string | `"/metrics"` | Path to scrape |

--- a/charts/ethereum-address-metrics-exporter/values.yaml
+++ b/charts/ethereum-address-metrics-exporter/values.yaml
@@ -180,7 +180,7 @@ serviceMonitor:
   # -- Additional ServiceMonitor annotations
   annotations: {}
   # -- ServiceMonitor scrape interval
-  interval: 15s
+  interval: 1m
   # -- ServiceMonitor scheme
   scheme: http
   # -- ServiceMonitor TLS configuration


### PR DESCRIPTION
Default chart value for `ServiceMonitor` config is set with `interval` less than `scrapeTimeout`, which Grafana Alloy doesn't like:
```ts=2024-05-28T23:57:50.491815865Z level=error msg="error generating scrapeconfig from serviceMonitor" component_path=/ component_id=prometheus.operator.servicemonitors.service_monitors name=mainnet-mon-exporter err="scrape timeout greater than scrape interval for scrape config with job name \"serviceMonitor/default/mainnet-mon-exporter/0\""```