### PR TITLE
fix: change default service monitor values for ethereum-metrics-exporter

### DIFF
--- a/charts/ethereum-metrics-exporter/Chart.yaml
+++ b/charts/ethereum-metrics-exporter/Chart.yaml
@@ -3,7 +3,7 @@ name: ethereum-metrics-exporter
 description: A Prometheus metrics exporter for Ethereum consensus & execution nodes
 home: https://github.com/samcm/ethereum-metrics-exporter
 type: application
-version: 0.1.4
+version: 0.1.5
 maintainers:
   - name: samcm
     email: sam.calder-mason@ethereum.org

--- a/charts/ethereum-metrics-exporter/README.md
+++ b/charts/ethereum-metrics-exporter/README.md
@@ -1,7 +1,7 @@
 
 # ethereum-metrics-exporter
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Prometheus metrics exporter for Ethereum consensus & execution nodes
 
@@ -61,13 +61,13 @@ A Prometheus metrics exporter for Ethereum consensus & execution nodes
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
 | serviceMonitor.annotations | object | `{}` | Additional ServiceMonitor annotations |
 | serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator https://github.com/coreos/prometheus-operator |
-| serviceMonitor.interval | string | `"15s"` | ServiceMonitor scrape interval |
+| serviceMonitor.interval | string | `"30s"` | ServiceMonitor scrape interval |
 | serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
 | serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor |
 | serviceMonitor.path | string | `"/metrics"` | Path to scrape |
 | serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabelings |
 | serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
-| serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
+| serviceMonitor.scrapeTimeout | string | `"15s"` | ServiceMonitor scrape timeout |
 | serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
 | terminationGracePeriodSeconds | int | `30` | How long to wait until the pod is forcefully terminated |
 | tolerations | list | `[]` | Tolerations for pods |

--- a/charts/ethereum-metrics-exporter/values.yaml
+++ b/charts/ethereum-metrics-exporter/values.yaml
@@ -187,12 +187,12 @@ serviceMonitor:
   # -- Additional ServiceMonitor annotations
   annotations: {}
   # -- ServiceMonitor scrape interval
-  interval: 15s
+  interval: 30s
   # -- ServiceMonitor scheme
   scheme: http
   # -- ServiceMonitor TLS configuration
   tlsConfig: {}
   # -- ServiceMonitor scrape timeout
-  scrapeTimeout: 30s
+  scrapeTimeout: 15s
   # -- ServiceMonitor relabelings
   relabelings: []


### PR DESCRIPTION
Default value for service monitor is wrong as scrape timeout is longer than scape interval, this is from prometheus operator with default value

error="scrapeTimeout \"30s\" greater than scrapeInterval \"15s\""