### PR TITLE
feat: add erpc chart

### DIFF
--- a/charts/erpc/.helmignore
+++ b/charts/erpc/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/erpc/Chart.lock
+++ b/charts/erpc/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.0.6
-digest: sha256:17cd575c95fedbdea81deeec083f073871065996a3bd4ad9034b0065144b5991
-generated: "2024-10-28T17:07:16.21681684+01:00"

--- a/charts/erpc/Chart.lock
+++ b/charts/erpc/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 13.4.4
+digest: sha256:fd3eac77c75e9be16f0b6f6bfc7e03e469a6a5651e5a561592c21f4bde5e1ff5
+generated: "2024-10-28T12:32:40.462542691+01:00"

--- a/charts/erpc/Chart.lock
+++ b/charts/erpc/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
   repository: https://charts.bitnami.com/bitnami
-  version: 13.4.4
-digest: sha256:fd3eac77c75e9be16f0b6f6bfc7e03e469a6a5651e5a561592c21f4bde5e1ff5
-generated: "2024-10-28T12:32:40.462542691+01:00"
+  version: 16.0.6
+digest: sha256:17cd575c95fedbdea81deeec083f073871065996a3bd4ad9034b0065144b5991
+generated: "2024-10-28T17:07:16.21681684+01:00"

--- a/charts/erpc/Chart.yaml
+++ b/charts/erpc/Chart.yaml
@@ -9,11 +9,3 @@ maintainers:
     email: busa.barnabas@gmail.com
   - name: pk910
     email: pk910@pk910.de
-dependencies:
-  - name: postgresql
-    # unclear if version 13.4 (3 years old) is a strict requirement
-    # https://github.com/erpc/erpc/blob/main/docker-compose.yml#L30
-    # since bitnami does not package a chart compatible with that version, default to 16.0.6 with postgres 17.0.0
-    version: "16.0.6"
-    repository: "https://charts.bitnami.com/bitnami"
-    condition: postgresql.enabled

--- a/charts/erpc/Chart.yaml
+++ b/charts/erpc/Chart.yaml
@@ -11,6 +11,9 @@ maintainers:
     email: pk910@pk910.de
 dependencies:
   - name: postgresql
-    version: "13.4.x"
+    # unclear if version 13.4 (3 years old) is a strict requirement
+    # https://github.com/erpc/erpc/blob/main/docker-compose.yml#L30
+    # since bitnami does not package a chart compatible with that version, default to 16.0.6 with postgres 17.0.0
+    version: "16.0.6"
     repository: "https://charts.bitnami.com/bitnami"
     condition: postgresql.enabled

--- a/charts/erpc/Chart.yaml
+++ b/charts/erpc/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: erpc
+description: eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching solution. It is built with read-heavy use-cases in mind such as data indexing and high-load frontend usage.
+home: https://github.com/erpc/erpc
+type: application
+version: 0.0.1
+maintainers:
+  - name: barnabasbusa
+    email: busa.barnabas@gmail.com
+  - name: pk910
+    email: pk910@pk910.de
+dependencies:
+  - name: postgresql
+    version: "13.4.x"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: postgresql.enabled

--- a/charts/erpc/README.md
+++ b/charts/erpc/README.md
@@ -7,12 +7,6 @@ eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching soluti
 
 **Homepage:** <https://github.com/erpc/erpc>
 
-## Requirements
-
-| Repository | Name | Version |
-|------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 16.0.6 |
-
 ## Values
 
 | Key | Type | Default | Description |
@@ -55,17 +49,6 @@ eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching soluti
 | podDisruptionBudget | object | `{}` | Define the PodDisruptionBudget spec If not set then a PodDisruptionBudget will not be created |
 | podLabels | object | `{}` | Pod labels |
 | podManagementPolicy | string | `"OrderedReady"` | Pod management policy |
-| postgresql.auth.database | string | `"rpc_cache"` |  |
-| postgresql.auth.enablePostgresUser | bool | `true` |  |
-| postgresql.auth.password | string | `"postgres"` |  |
-| postgresql.auth.postgresPassword | string | `"postgres"` |  |
-| postgresql.auth.username | string | `"postgres"` |  |
-| postgresql.enabled | bool | `false` |  |
-| postgresql.name | string | `"{{ .Release.Name }}-postgresql"` | If enabled a postgres chart will be deployed as a dependency |
-| postgresql.persistence.enabled | bool | `true` |  |
-| postgresql.persistence.size | string | `"8Gi"` |  |
-| postgresql.primary.extendedConfiguration | string | `"max_connections = 1024\n"` |  |
-| postgresql.pullPolicy | string | `"IfNotPresent"` |  |
 | priorityClassName | string | `nil` | Pod priority class |
 | readinessProbe | object | See `values.yaml` | Readiness probe |
 | replicas | int | `1` | Number of replicas |

--- a/charts/erpc/README.md
+++ b/charts/erpc/README.md
@@ -75,23 +75,10 @@ eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching soluti
 | updateStrategy | object | `{"type":"RollingUpdate"}` | Update stategy for the Statefulset |
 | updateStrategy.type | string | `"RollingUpdate"` | Update stategy type |
 
-# Example
+# Getting Started
 
-Usage: dora-explorer -config config.yaml
+Update the `config` field to configure the various upstreams that you want to proxy with eRPC.
 
-Helper:
-```shell
-Usage of ./dora-explorer:
--config string
-    Path to the config file, if empty string defaults will be used
-```
+The `secretEnv` field can be used to securely add API keys to your configuration.
 
-In order to name validators based on ranges the following file format can be provided YAML:
-```yaml
-0-500: validator_set_A
-500-1000: validator_set_B
-1000-1500: validator_set_C
-...
-```
-
-More details can be found [here](https://github.com/pk910/dora).
+For more information, check out the [eRPC repository](https://github.com/erpc/erpc).

--- a/charts/erpc/README.md
+++ b/charts/erpc/README.md
@@ -53,7 +53,7 @@ eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching soluti
 | readinessProbe | object | See `values.yaml` | Readiness probe |
 | replicas | int | `1` | Number of replicas |
 | resources | object | `{}` | Resource requests and limits |
-| secretEnv | object | `{}` | Additional env variables injected via a created secret |
+| secretEnv | object | `{"ALCHEMY_API_KEY":"XXXXXXXXXX"}` | Secret env variables injected via a created secret These env variables can be used to populate the erpc config file with sensitive data such as RPC API keys |
 | securityContext | object | See `values.yaml` | The security context for pods |
 | service.type | string | `"ClusterIP"` | Service type |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/erpc/README.md
+++ b/charts/erpc/README.md
@@ -11,7 +11,7 @@ eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching soluti
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | postgresql | 13.4.x |
+| https://charts.bitnami.com/bitnami | postgresql | 16.0.6 |
 
 ## Values
 
@@ -41,6 +41,7 @@ eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching soluti
 | ingress.tls | list | `[]` | Ingress TLS |
 | initContainers | list | `[]` | Additional init containers |
 | livenessProbe | object | See `values.yaml` | Liveness probe |
+| metricsPort | int | `4001` |  |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | Node selector for pods |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
@@ -54,15 +55,12 @@ eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching soluti
 | podDisruptionBudget | object | `{}` | Define the PodDisruptionBudget spec If not set then a PodDisruptionBudget will not be created |
 | podLabels | object | `{}` | Pod labels |
 | podManagementPolicy | string | `"OrderedReady"` | Pod management policy |
-| postgresql.auth.database | string | `"erpc"` |  |
+| postgresql.auth.database | string | `"rpc_cache"` |  |
 | postgresql.auth.enablePostgresUser | bool | `true` |  |
 | postgresql.auth.password | string | `"postgres"` |  |
 | postgresql.auth.postgresPassword | string | `"postgres"` |  |
 | postgresql.auth.username | string | `"postgres"` |  |
-| postgresql.enabled | bool | `true` |  |
-| postgresql.image.registry | string | `"docker.io"` |  |
-| postgresql.image.repository | string | `"bitnami/postgresql"` |  |
-| postgresql.image.tag | string | `"15.3.0-debian-11-r7"` |  |
+| postgresql.enabled | bool | `false` |  |
 | postgresql.name | string | `"{{ .Release.Name }}-postgresql"` | If enabled a postgres chart will be deployed as a dependency |
 | postgresql.persistence.enabled | bool | `true` |  |
 | postgresql.persistence.size | string | `"8Gi"` |  |

--- a/charts/erpc/README.md
+++ b/charts/erpc/README.md
@@ -1,0 +1,116 @@
+
+# erpc
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching solution. It is built with read-heavy use-cases in mind such as data indexing and high-load frontend usage.
+
+**Homepage:** <https://github.com/erpc/erpc>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://charts.bitnami.com/bitnami | postgresql | 13.4.x |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity configuration for pods |
+| annotations | object | `{}` | Annotations for the StatefulSet |
+| config | string | See `values.yaml` | Config file |
+| containerSecurityContext | object | See `values.yaml` | The security context for containers |
+| customCommand | list | `[]` | Command replacement for the erpc container |
+| extraArgs | list | `[]` | Extra args for the erpc container |
+| extraContainers | list | `[]` | Additional containers |
+| extraEnv | list | `[]` | Additional env variables |
+| extraPorts | list | `[]` | Additional ports. Useful when using extraContainers |
+| extraVolumeMounts | list | `[]` | Additional volume mounts |
+| extraVolumes | list | `[]` | Additional volumes |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| httpPort | int | `4000` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | erpc container pull policy |
+| image.repository | string | `"ghcr.io/erpc/erpc"` | erpc container image repository |
+| image.tag | string | `"0.0.26"` | erpc container image tag |
+| imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
+| ingress.annotations | object | `{}` | Annotations for Ingress |
+| ingress.enabled | bool | `false` | Ingress resource for the HTTP API |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths | list | `[]` |  |
+| ingress.tls | list | `[]` | Ingress TLS |
+| initContainers | list | `[]` | Additional init containers |
+| livenessProbe | object | See `values.yaml` | Liveness probe |
+| nameOverride | string | `""` | Overrides the chart's name |
+| nodeSelector | object | `{}` | Node selector for pods |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
+| persistence.annotations | object | `{}` | Annotations for volume claim template |
+| persistence.enabled | bool | `false` | Uses an EmptyDir when not enabled |
+| persistence.existingClaim | string | `nil` | Use an existing PVC when persistence.enabled |
+| persistence.selector | object | `{}` | Selector for volume claim template |
+| persistence.size | string | `"1Gi"` | Requested size for volume claim template |
+| persistence.storageClassName | string | `nil` | Use a specific storage class E.g 'local-path' for local storage to achieve best performance Read more (https://github.com/rancher/local-path-provisioner) |
+| podAnnotations | object | `{}` | Pod annotations |
+| podDisruptionBudget | object | `{}` | Define the PodDisruptionBudget spec If not set then a PodDisruptionBudget will not be created |
+| podLabels | object | `{}` | Pod labels |
+| podManagementPolicy | string | `"OrderedReady"` | Pod management policy |
+| postgresql.auth.database | string | `"erpc"` |  |
+| postgresql.auth.enablePostgresUser | bool | `true` |  |
+| postgresql.auth.password | string | `"postgres"` |  |
+| postgresql.auth.postgresPassword | string | `"postgres"` |  |
+| postgresql.auth.username | string | `"postgres"` |  |
+| postgresql.enabled | bool | `true` |  |
+| postgresql.image.registry | string | `"docker.io"` |  |
+| postgresql.image.repository | string | `"bitnami/postgresql"` |  |
+| postgresql.image.tag | string | `"15.3.0-debian-11-r7"` |  |
+| postgresql.name | string | `"{{ .Release.Name }}-postgresql"` | If enabled a postgres chart will be deployed as a dependency |
+| postgresql.persistence.enabled | bool | `true` |  |
+| postgresql.persistence.size | string | `"8Gi"` |  |
+| postgresql.primary.extendedConfiguration | string | `"max_connections = 1024\n"` |  |
+| postgresql.pullPolicy | string | `"IfNotPresent"` |  |
+| priorityClassName | string | `nil` | Pod priority class |
+| readinessProbe | object | See `values.yaml` | Readiness probe |
+| replicas | int | `1` | Number of replicas |
+| resources | object | `{}` | Resource requests and limits |
+| secretEnv | object | `{}` | Additional env variables injected via a created secret |
+| securityContext | object | See `values.yaml` | The security context for pods |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor.annotations | object | `{}` | Additional ServiceMonitor annotations |
+| serviceMonitor.enabled | bool | `false` | If true, a ServiceMonitor CRD is created for a prometheus operator https://github.com/coreos/prometheus-operator |
+| serviceMonitor.interval | string | `"1m"` | ServiceMonitor scrape interval |
+| serviceMonitor.labels | object | `{}` | Additional ServiceMonitor labels |
+| serviceMonitor.namespace | string | `nil` | Alternative namespace for ServiceMonitor |
+| serviceMonitor.path | string | `"/metrics"` | Path to scrape |
+| serviceMonitor.relabelings | list | `[]` | ServiceMonitor relabelings |
+| serviceMonitor.scheme | string | `"http"` | ServiceMonitor scheme |
+| serviceMonitor.scrapeTimeout | string | `"30s"` | ServiceMonitor scrape timeout |
+| serviceMonitor.tlsConfig | object | `{}` | ServiceMonitor TLS configuration |
+| terminationGracePeriodSeconds | int | `30` | How long to wait until the pod is forcefully terminated |
+| tolerations | list | `[]` | Tolerations for pods |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pods |
+| updateStrategy | object | `{"type":"RollingUpdate"}` | Update stategy for the Statefulset |
+| updateStrategy.type | string | `"RollingUpdate"` | Update stategy type |
+
+# Example
+
+Usage: dora-explorer -config config.yaml
+
+Helper:
+```shell
+Usage of ./dora-explorer:
+-config string
+    Path to the config file, if empty string defaults will be used
+```
+
+In order to name validators based on ranges the following file format can be provided YAML:
+```yaml
+0-500: validator_set_A
+500-1000: validator_set_B
+1000-1500: validator_set_C
+...
+```
+
+More details can be found [here](https://github.com/pk910/dora).

--- a/charts/erpc/README.md.gotmpl
+++ b/charts/erpc/README.md.gotmpl
@@ -1,0 +1,36 @@
+
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+# Example
+
+Usage: dora-explorer -config config.yaml
+
+Helper:
+```shell
+Usage of ./dora-explorer:
+-config string
+    Path to the config file, if empty string defaults will be used
+```
+
+In order to name validators based on ranges the following file format can be provided YAML:
+```yaml
+0-500: validator_set_A
+500-1000: validator_set_B
+1000-1500: validator_set_C
+...
+```
+
+More details can be found [here](https://github.com/pk910/dora).

--- a/charts/erpc/README.md.gotmpl
+++ b/charts/erpc/README.md.gotmpl
@@ -14,23 +14,10 @@
 
 {{ template "chart.valuesSection" . }}
 
-# Example
+# Getting Started
 
-Usage: dora-explorer -config config.yaml
+Update the `config` field to configure the various upstreams that you want to proxy with eRPC.
 
-Helper:
-```shell
-Usage of ./dora-explorer:
--config string
-    Path to the config file, if empty string defaults will be used
-```
+The `secretEnv` field can be used to securely add API keys to your configuration.
 
-In order to name validators based on ranges the following file format can be provided YAML:
-```yaml
-0-500: validator_set_A
-500-1000: validator_set_B
-1000-1500: validator_set_C
-...
-```
-
-More details can be found [here](https://github.com/pk910/dora).
+For more information, check out the [eRPC repository](https://github.com/erpc/erpc).

--- a/charts/erpc/templates/_helpers.tpl
+++ b/charts/erpc/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "erpc.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "erpc.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "erpc.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "erpc.labels" -}}
+helm.sh/chart: {{ include "erpc.chart" . }}
+{{ include "erpc.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "erpc.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "erpc.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "erpc.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "erpc.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/erpc/templates/configmap.yaml
+++ b/charts/erpc/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "erpc.fullname" . }}-config
+  labels:
+    {{- include "erpc.labels" . | nindent 4 }}
+data:
+  erpc.yaml: |
+    {{- tpl .Values.config . | nindent 4 }}

--- a/charts/erpc/templates/deployment.yaml
+++ b/charts/erpc/templates/deployment.yaml
@@ -46,9 +46,7 @@ spec:
           {{- if gt (len .Values.customCommand) 0 }}
             {{- toYaml .Values.customCommand | nindent 12}}
           {{- else }}
-              - ./erpc-explorer
-              - -config
-              - /data/config.yaml
+              - ./erpc-server
           {{- end }}
           {{- if gt (len .Values.extraArgs) 0 }}
           args:
@@ -103,6 +101,3 @@ spec:
         - name: config
           configMap:
             name: {{ include "erpc.fullname" . }}-config
-        - name: ranges
-          configMap: 
-            name: {{ include "erpc.fullname" . }}-ranges

--- a/charts/erpc/templates/deployment.yaml
+++ b/charts/erpc/templates/deployment.yaml
@@ -58,12 +58,8 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: "/data/config.yaml"
-              subPath: config.yaml
-              readOnly: true
-            - name: ranges
-              mountPath: "/data/ranges.yaml"
-              subPath: ranges.yaml
+              mountPath: /root/erpc.yaml"
+              subPath: erpc.yaml
               readOnly: true
             {{- if .Values.extraVolumeMounts }}
             {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
@@ -71,6 +67,9 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.httpPort }}
+              protocol: TCP
+            - name: metrics
+              containerPort: {{ .Values.metricsPort }}
               protocol: TCP
             {{- if .Values.extraPodPorts }}
             {{ toYaml .Values.extraPodPorts | nindent 12 }}

--- a/charts/erpc/templates/deployment.yaml
+++ b/charts/erpc/templates/deployment.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "erpc.fullname" . }}
+  labels:
+    {{- include "erpc.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "erpc.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "erpc.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "erpc.serviceAccountName" . }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      initContainers:
+      {{- if .Values.initContainers }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+          {{- if gt (len .Values.customCommand) 0 }}
+            {{- toYaml .Values.customCommand | nindent 12}}
+          {{- else }}
+              - ./erpc-explorer
+              - -config
+              - /data/config.yaml
+          {{- end }}
+          {{- if gt (len .Values.extraArgs) 0 }}
+          args:
+            {{- toYaml .Values.extraArgs | nindent 12}}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: "/data/config.yaml"
+              subPath: config.yaml
+              readOnly: true
+            - name: ranges
+              mountPath: "/data/ranges.yaml"
+              subPath: ranges.yaml
+              readOnly: true
+            {{- if .Values.extraVolumeMounts }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.httpPort }}
+              protocol: TCP
+            {{- if .Values.extraPodPorts }}
+            {{ toYaml .Values.extraPodPorts | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+          {{- if .Values.extraEnv }}
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
+        {{- if .Values.extraContainers }}
+        {{ toYaml .Values.extraContainers | nindent 8}}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      volumes:
+      {{- if .Values.extraVolumes }}
+        {{ toYaml .Values.extraVolumes | nindent 8}}
+      {{- end }}
+        - name: config
+          configMap:
+            name: {{ include "erpc.fullname" . }}-config
+        - name: ranges
+          configMap: 
+            name: {{ include "erpc.fullname" . }}-ranges

--- a/charts/erpc/templates/deployment.yaml
+++ b/charts/erpc/templates/deployment.yaml
@@ -47,6 +47,7 @@ spec:
             {{- toYaml .Values.customCommand | nindent 12}}
           {{- else }}
               - ./erpc-server
+              - /erpc.yaml
           {{- end }}
           {{- if gt (len .Values.extraArgs) 0 }}
           args:
@@ -56,7 +57,7 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /root/erpc.yaml
+              mountPath: /erpc.yaml
               subPath: erpc.yaml
               readOnly: true
             {{- if .Values.extraVolumeMounts }}

--- a/charts/erpc/templates/deployment.yaml
+++ b/charts/erpc/templates/deployment.yaml
@@ -55,6 +55,9 @@ spec:
           {{- end }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          envFrom:
+          - secretRef:
+              name: {{ include "erpc.fullname" . }}-envs
           volumeMounts:
             - name: config
               mountPath: /erpc.yaml

--- a/charts/erpc/templates/deployment.yaml
+++ b/charts/erpc/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           volumeMounts:
             - name: config
-              mountPath: /root/erpc.yaml"
+              mountPath: /root/erpc.yaml
               subPath: erpc.yaml
               readOnly: true
             {{- if .Values.extraVolumeMounts }}

--- a/charts/erpc/templates/ingress.yaml
+++ b/charts/erpc/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled -}}
-{{- $fullName := include "dora.fullname" . -}}
+{{- $fullName := include "erpc.fullname" . -}}
 {{- $svcPort := .Values.httpPort -}}
 {{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
   {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
@@ -17,7 +17,7 @@ kind: Ingress
 metadata:
   name: {{ $fullName }}
   labels:
-    {{- include "dora.labels" . | nindent 4 }}
+    {{- include "erpc.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/erpc/templates/ingress.yaml
+++ b/charts/erpc/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "dora.fullname" . -}}
+{{- $svcPort := .Values.httpPort -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "dora.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/erpc/templates/secret.yaml
+++ b/charts/erpc/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "erpc.fullname" . }}-envs
+  labels:
+    {{- include "erpc.labels" . | nindent 4 }}
+data:
+{{- range $key, $value := .Values.secretEnv }}
+  {{ $key }}: {{ $value | b64enc }}
+{{- end }}

--- a/charts/erpc/templates/service.yaml
+++ b/charts/erpc/templates/service.yaml
@@ -11,6 +11,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.metricsPort }}
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
   {{- if .Values.extraPorts }}
     {{ toYaml .Values.extraPorts | nindent 4}}
   {{- end }}

--- a/charts/erpc/templates/service.yaml
+++ b/charts/erpc/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "erpc.fullname" . }}
+  labels:
+    {{- include "erpc.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  {{- if .Values.extraPorts }}
+    {{ toYaml .Values.extraPorts | nindent 4}}
+  {{- end }}
+  selector:
+    {{- include "erpc.selectorLabels" . | nindent 4 }}

--- a/charts/erpc/templates/serviceaccount.yaml
+++ b/charts/erpc/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "erpc.serviceAccountName" . }}
+  labels:
+    {{- include "erpc.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/erpc/templates/servicemonitor.yaml
+++ b/charts/erpc/templates/servicemonitor.yaml
@@ -22,9 +22,9 @@ spec:
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
     {{- end }}
     honorLabels: true
-    port: http
-    path: {{ .Values.serviceMonitor.path }}
-    scheme: {{ .Values.serviceMonitor.scheme }}
+    port: metrics
+    path: {{ . Values.serviceMonitor.path }}
+    scheme: {{.Values.serviceMonitor.scheme }}
     {{- if .Values.serviceMonitor.tlsConfig }}
     tlsConfig:
     {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}

--- a/charts/erpc/templates/servicemonitor.yaml
+++ b/charts/erpc/templates/servicemonitor.yaml
@@ -23,7 +23,7 @@ spec:
     {{- end }}
     honorLabels: true
     port: metrics
-    path: {{ . Values.serviceMonitor.path }}
+    path: {{ .Values.serviceMonitor.path }}
     scheme: {{.Values.serviceMonitor.scheme }}
     {{- if .Values.serviceMonitor.tlsConfig }}
     tlsConfig:

--- a/charts/erpc/templates/servicemonitor.yaml
+++ b/charts/erpc/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "erpc.serviceAccountName" . }}
+  {{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+    {{- include "erpc.labels" . | nindent 4 }}
+    {{- if .Values.serviceMonitor.labels }}
+    {{- toYaml .Values.serviceMonitor.labels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+  {{ toYaml .Values.serviceMonitor.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+  - interval: {{ .Values.serviceMonitor.interval }}
+    {{- if .Values.serviceMonitor.scrapeTimeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    {{- end }}
+    honorLabels: true
+    port: http
+    path: {{ .Values.serviceMonitor.path }}
+    scheme: {{ .Values.serviceMonitor.scheme }}
+    {{- if .Values.serviceMonitor.tlsConfig }}
+    tlsConfig:
+    {{- toYaml .Values.serviceMonitor.tlsConfig | nindent 6 }}
+    {{- end }}
+    {{- if .Values.serviceMonitor.relabelings }}
+    relabelings:
+    {{- toYaml .Values.serviceMonitor.relabelings | nindent 4 }}
+    {{- end }}
+  jobLabel: "{{ .Release.Name }}"
+  selector:
+    matchLabels:
+      {{- include "erpc.selectorLabels" . | nindent 8 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+{{- end }}

--- a/charts/erpc/templates/tests/test-connection.yaml
+++ b/charts/erpc/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "erpc.fullname" . }}-test-connection"
+  labels:
+    {{- include "erpc.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "erpc.fullname" . }}:{{ .Values.httpPort }}']
+  restartPolicy: Never

--- a/charts/erpc/templates/tests/test-connection.yaml
+++ b/charts/erpc/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "erpc.fullname" . }}:{{ .Values.httpPort }}']
+      args: ['{{ include "erpc.fullname" . }}:{{ .Values.httpPort }}/healthcheck']
   restartPolicy: Never

--- a/charts/erpc/values.yaml
+++ b/charts/erpc/values.yaml
@@ -39,7 +39,12 @@ config: |
     projects:
       - id: main
         upstreams:
-          - endpoint: alchemy://XXXXXXXXXXX
+          - endpoint: alchemy://${ALCHEMY_API_KEY}
+
+# -- Secret env variables injected via a created secret
+# These env variables can be used to populate the erpc config file with sensitive data such as RPC API keys
+secretEnv:
+  ALCHEMY_API_KEY: XXXXXXXXXX
 
 # - HTTP port for erpc
 httpPort: 4000
@@ -192,9 +197,6 @@ extraPorts: []
 
 # -- Additional env variables
 extraEnv: []
-
-# -- Additional env variables injected via a created secret
-secretEnv: {}
 
 persistence:
   # -- Uses an EmptyDir when not enabled

--- a/charts/erpc/values.yaml
+++ b/charts/erpc/values.yaml
@@ -1,0 +1,438 @@
+# -- Overrides the chart's name
+nameOverride: ""
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+# -- Number of replicas
+replicas: 1
+
+image:
+  # -- erpc container image repository
+  repository: ghcr.io/erpc/erpc
+  # -- erpc container image tag
+  tag: 0.0.26
+  # -- erpc container pull policy
+  pullPolicy: IfNotPresent
+
+# -- Config file
+# @default -- See `values.yaml`
+config: |
+    # Log level helps in debugging or error detection:
+    # - debug: information down to actual request and responses, and decisions about rate-liming etc.
+    # - info: usually prints happy paths and might print 1 log per request indicating of success or failure.
+    # - warn: these problems do not cause end-user problems, but might indicate degredataion or an issue such as cache databse being down.
+    # - error: these are problems that have end-user impact, such as misconfigurations.
+    logLevel: warn
+    
+    # There are various use-cases of database in erpc, such as caching, dynamic configs, rate limit persistence, etc.
+    database:
+      # `evmJsonRpcCache` defines the destination for caching JSON-RPC cals towards any EVM architecture upstream.
+      # This database is non-blocking on critical path, and is used as best-effort.
+      # Make sure the storage requirements meet your usage, for example caching 70m blocks + 10m txs + 10m traces on Arbitrum needs 200GB of storage.
+      evmJsonRpcCache:
+        # Refer to "Database" section for more details.
+        # Note that table, schema and indexes will be created automatically if they don't exist.
+        driver: postgresql
+        postgresql:
+          connectionUri: >-
+            postgres://YOUR_USERNAME_HERE:YOUR_PASSWORD_HERE@your.postgres.hostname.here.com:5432/your_database_name
+          table: rpc_cache
+    
+    # The main server for eRPC to listen for requests.
+    server:
+      listenV4: true
+      httpHostV4: "0.0.0.0"
+      listenV6: false
+      httpHostV6: "[::]"
+      httpPort: 4000
+      maxTimeout: 30s
+    
+    # Optional Prometheus metrics server.
+    metrics:
+      enabled: true
+      listenV4: true
+      hostV4: "0.0.0.0"
+      listenV6: false
+      hostV6: "[::]"
+      port: 4001
+    
+    # Each project is a collection of networks and upstreams.
+    # For example "backend", "indexer", "frontend", and you want to use only 1 project you can name it "main"
+    # The main purpose of multiple projects is different failsafe policies (more aggressive and costly, or less costly and more error-prone)
+    projects:
+      - id: main
+    
+        # Optionally you can define a self-imposed rate limite budget for each project
+        # This is useful if you want to limit the number of requests per second or daily allowance.
+        rateLimitBudget: frontend-budget
+    
+        # This array configures network-specific (a.k.a chain-specific) features.
+        # For each network "architecture" and corresponding network id (e.g. evm.chainId) is required.
+        # Remember defining networks is OPTIONAL, so only provide these only if you want to override defaults.
+        networks:
+          - architecture: evm
+            evm:
+              chainId: 1
+            # Refer to "Failsafe" section for more details.
+            # On network-level "timeout" is applied for the whole lifecycle of the request (including however many retries)
+            failsafe:
+              timeout:
+                duration: 30s
+              retry:
+                maxCount: 3
+                delay: 500ms
+                backoffMaxDelay: 10s
+                backoffFactor: 0.3
+                jitter: 500ms
+              # Defining a "hedge" is highly-recommended on network-level because if upstream A is being slow for
+              # a specific request, it can start a new parallel hedged request to upstream B, for whichever responds faster.
+              hedge:
+                delay: 3000ms
+                maxCount: 2
+              circuitBreaker:
+                failureThresholdCount: 30
+                failureThresholdCapacity: 100
+                halfOpenAfter: 60s
+                successThresholdCount: 8
+                successThresholdCapacity: 10
+          - architecture: evm
+            evm:
+              chainId: 42161
+            failsafe:
+              timeout:
+                duration: 30s
+              retry:
+                maxCount: 5
+                delay: 500ms
+                backoffMaxDelay: 10s
+                backoffFactor: 0.3
+                jitter: 200ms
+              hedge:
+                delay: 1000ms
+                maxCount: 2
+    
+        # Each upstream supports 1 or more networks (chains)
+        upstreams:
+          - id: blastapi-chain-42161
+            type: evm
+            endpoint: https://arbitrum-one.blastapi.io/xxxxxxx-xxxxxx-xxxxxxx
+            # Defines which budget to use when hadnling requests of this upstream.
+            rateLimitBudget: global-blast
+            # chainId is optional and will be detected from the endpoint (eth_chainId) but it is recommended to set it explicitly, for faster initialization.
+            evm:
+              chainId: 42161
+            # Which methods must never be sent to this upstream:
+            ignoreMethods:
+              - "alchemy_*"
+              - "eth_traceTransaction"
+            # Refer to "Failsafe" section for more details:
+            failsafe:
+              timeout:
+                duration: 15s
+              retry:
+                maxCount: 2
+                delay: 1000ms
+                backoffMaxDelay: 10s
+                backoffFactor: 0.3
+                jitter: 500ms
+          - id: blastapi-chain-1
+            type: evm
+            endpoint: https://eth-mainnet.blastapi.io/xxxxxxx-xxxxxx-xxxxxxx
+            rateLimitBudget: global-blast
+            evm:
+              chainId: 1
+            failsafe:
+              timeout:
+                duration: 15s
+              retry:
+                maxCount: 2
+                delay: 1000ms
+                backoffMaxDelay: 10s
+                backoffFactor: 0.3
+                jitter: 500ms
+          - id: quiknode-chain-42161
+            type: evm
+            endpoint: https://xxxxxx-xxxxxx.arbitrum-mainnet.quiknode.pro/xxxxxxxxxxxxxxxxxxxxxxxx/
+            rateLimitBudget: global-quicknode
+            # You can disable auto-ignoring unsupported methods, and instead define them explicitly.
+            # This is useful if provider (e.g. dRPC) is not consistent with "unsupported method" responses.
+            autoIgnoreUnsupportedMethods: false
+            # To allow auto-batching requests towards the upstream, use these settings.
+            # Remember if "supportsBatch" is false, you still can send batch requests to eRPC
+            # but they will be sent to upstream as individual requests.
+            jsonRpc:
+              supportsBatch: true
+              batchMaxSize: 10
+              batchMaxWait: 100ms
+            evm:
+              chainId: 42161
+            failsafe:
+              timeout:
+                duration: 15s
+              retry:
+                maxCount: 2
+                delay: 1000ms
+                backoffMaxDelay: 10s
+                backoffFactor: 0.3
+                jitter: 500ms
+    
+            # "id" is a unique identifier to distinguish in logs and metrics.
+          - id: alchemy-multi-chain-example
+            # For certain known providers (such as Alchemy) you use a custom protocol name
+            # which allows a single upstream to import "all chains" supported by that provider.
+            # Note that these chains are hard-coded in the repo, so if they support a new chain eRPC must be updated.
+            endpoint: alchemy://XXXX_YOUR_ALCHEMY_API_KEY_HERE_XXXX
+            rateLimitBudget: global
+            failsafe:
+              timeout:
+                duration: 15s
+              retry:
+                maxCount: 2
+                delay: 1000ms
+                backoffMaxDelay: 10s
+                backoffFactor: 0.3
+                jitter: 500ms
+    
+    # Rate limiter allows you to create "shared" budgets for upstreams.
+    # For example upstream A and B can use the same budget, which means both of them together must not exceed the defined limits.
+    rateLimiters:
+      budgets:
+        - id: default-budget
+          rules:
+            - method: "*"
+              maxCount: 10000
+              period: 1s
+        - id: global-blast
+          rules:
+            - method: "*"
+              maxCount: 1000
+              period: 1s
+        - id: global-quicknode
+          rules:
+            - method: "*"
+              maxCount: 300
+              period: 1s
+        - id: frontend-budget
+          rules:
+            - method: "*"
+              maxCount: 500
+              period: 1s
+
+# - HTTP port for erpc interface
+httpPort: 4000
+
+# -- Extra args for the erpc container
+extraArgs: []
+
+# -- Command replacement for the erpc container
+customCommand: []
+
+ingress:
+  # -- Ingress resource for the HTTP API
+  enabled: false
+  # -- Annotations for Ingress
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # -- Ingress host
+  hosts:
+    - host: chart-example.local
+      paths: []
+  # -- Ingress TLS
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+service:
+  # -- Service type
+  type: ClusterIP
+
+# -- Affinity configuration for pods
+affinity: {}
+
+# -- Image pull secrets for Docker images
+imagePullSecrets: []
+
+# -- Annotations for the StatefulSet
+annotations: {}
+
+# -- Liveness probe
+# @default -- See `values.yaml`
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 60
+  periodSeconds: 120
+
+# -- Readiness probe
+# @default -- See `values.yaml`
+readinessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+# -- Node selector for pods
+nodeSelector: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod management policy
+podManagementPolicy: OrderedReady
+
+# -- Pod priority class
+priorityClassName: null
+
+# -- Resource requests and limits
+resources: {}
+# limits:
+#   cpu: 500m
+#   memory: 2Gi
+# requests:
+#   cpu: 300m
+#   memory: 1Gi
+
+# -- The security context for pods
+# @default -- See `values.yaml`
+securityContext:
+  fsGroup: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+
+# -- The security context for containers
+# @default -- See `values.yaml`
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- How long to wait until the pod is forcefully terminated
+terminationGracePeriodSeconds: 30
+
+# -- Tolerations for pods
+## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
+# -- Topology Spread Constraints for pods
+## ref: https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/
+topologySpreadConstraints: []
+
+# -- Define the PodDisruptionBudget spec
+# If not set then a PodDisruptionBudget will not be created
+podDisruptionBudget: {}
+# minAvailable: 1
+# maxUnavailable: 1
+
+# -- Update stategy for the Statefulset
+updateStrategy:
+  # -- Update stategy type
+  type: RollingUpdate
+
+# -- Additional init containers
+initContainers: []
+# - name: my-init-container
+#   image: busybox:latest
+#   command: ['sh', '-c', 'echo hello']
+
+# -- Additional containers
+extraContainers: []
+
+# -- Additional volumes
+extraVolumes: []
+
+# -- Additional volume mounts
+extraVolumeMounts: []
+
+# -- Additional ports. Useful when using extraContainers
+extraPorts: []
+
+# -- Additional env variables
+extraEnv: []
+
+# -- Additional env variables injected via a created secret
+secretEnv: {}
+
+persistence:
+  # -- Uses an EmptyDir when not enabled
+  enabled: false
+  # -- Use an existing PVC when persistence.enabled
+  existingClaim: null
+  # -- Access mode for the volume claim template
+  accessModes:
+  - ReadWriteOnce
+  # -- Requested size for volume claim template
+  size: 1Gi
+  # -- Use a specific storage class
+  # E.g 'local-path' for local storage to achieve best performance
+  # Read more (https://github.com/rancher/local-path-provisioner)
+  storageClassName: null
+  # -- Annotations for volume claim template
+  annotations: {}
+  # -- Selector for volume claim template
+  selector: {}
+  #   matchLabels:
+  #     app.kubernetes.io/name: something
+
+serviceMonitor:
+  # -- If true, a ServiceMonitor CRD is created for a prometheus operator
+  # https://github.com/coreos/prometheus-operator
+  enabled: false
+  # -- Path to scrape
+  path: /metrics
+  # -- Alternative namespace for ServiceMonitor
+  namespace: null
+  # -- Additional ServiceMonitor labels
+  labels: {}
+  # -- Additional ServiceMonitor annotations
+  annotations: {}
+  # -- ServiceMonitor scrape interval
+  interval: 1m
+  # -- ServiceMonitor scheme
+  scheme: http
+  # -- ServiceMonitor TLS configuration
+  tlsConfig: {}
+  # -- ServiceMonitor scrape timeout
+  scrapeTimeout: 30s
+  # -- ServiceMonitor relabelings
+  relabelings: []
+
+postgresql:
+  # -- If enabled a postgres chart will be deployed as a dependency
+  name: "{{ .Release.Name }}-postgresql"
+  enabled: true
+  image:
+    registry: docker.io
+    repository: bitnami/postgresql
+    tag: 15.3.0-debian-11-r7
+  pullPolicy: IfNotPresent
+  auth:
+    enablePostgresUser: true
+    postgresPassword: postgres
+    database: erpc
+    username: postgres
+    password: postgres
+  primary:
+    extendedConfiguration: |
+      max_connections = 1024
+  persistence:
+    enabled: true
+    size: 8Gi

--- a/charts/erpc/values.yaml
+++ b/charts/erpc/values.yaml
@@ -125,11 +125,11 @@ resources: {}
 
 # -- The security context for pods
 # @default -- See `values.yaml`
-securityContext:
-  fsGroup: 10001
-  runAsGroup: 10001
-  runAsNonRoot: true
-  runAsUser: 10001
+securityContext: {}
+#  fsGroup: 10001
+#  runAsGroup: 10001
+#  runAsNonRoot: true
+#  runAsUser: 10001
 
 # -- The security context for containers
 # @default -- See `values.yaml`

--- a/charts/erpc/values.yaml
+++ b/charts/erpc/values.yaml
@@ -18,209 +18,41 @@ image:
 # -- Config file
 # @default -- See `values.yaml`
 config: |
-    # Log level helps in debugging or error detection:
-    # - debug: information down to actual request and responses, and decisions about rate-liming etc.
-    # - info: usually prints happy paths and might print 1 log per request indicating of success or failure.
-    # - warn: these problems do not cause end-user problems, but might indicate degredataion or an issue such as cache databse being down.
-    # - error: these are problems that have end-user impact, such as misconfigurations.
-    logLevel: warn
-    
-    # There are various use-cases of database in erpc, such as caching, dynamic configs, rate limit persistence, etc.
+    logLevel: debug
+
     database:
-      # `evmJsonRpcCache` defines the destination for caching JSON-RPC cals towards any EVM architecture upstream.
-      # This database is non-blocking on critical path, and is used as best-effort.
-      # Make sure the storage requirements meet your usage, for example caching 70m blocks + 10m txs + 10m traces on Arbitrum needs 200GB of storage.
       evmJsonRpcCache:
-        # Refer to "Database" section for more details.
-        # Note that table, schema and indexes will be created automatically if they don't exist.
-        driver: postgresql
-        postgresql:
-          connectionUri: >-
-            postgres://YOUR_USERNAME_HERE:YOUR_PASSWORD_HERE@your.postgres.hostname.here.com:5432/your_database_name
-          table: rpc_cache
-    
-    # The main server for eRPC to listen for requests.
+        driver: memory
+
+        ### example postgres configs ###
+        # driver: postgresql
+        # postgresql:
+        #   connectionUri: >-
+        #     postgres://YOUR_USERNAME_HERE:YOUR_PASSWORD_HERE@{{ .Release.Name }}-postgresql:5432/rpc_cache
+        #   table: rpc_cache
+
     server:
-      listenV4: true
       httpHostV4: "0.0.0.0"
-      listenV6: false
+      listenV6: true
       httpHostV6: "[::]"
       httpPort: 4000
-      maxTimeout: 30s
-    
-    # Optional Prometheus metrics server.
+
     metrics:
       enabled: true
-      listenV4: true
       hostV4: "0.0.0.0"
-      listenV6: false
       hostV6: "[::]"
       port: 4001
-    
-    # Each project is a collection of networks and upstreams.
-    # For example "backend", "indexer", "frontend", and you want to use only 1 project you can name it "main"
-    # The main purpose of multiple projects is different failsafe policies (more aggressive and costly, or less costly and more error-prone)
+
     projects:
       - id: main
-    
-        # Optionally you can define a self-imposed rate limite budget for each project
-        # This is useful if you want to limit the number of requests per second or daily allowance.
-        rateLimitBudget: frontend-budget
-    
-        # This array configures network-specific (a.k.a chain-specific) features.
-        # For each network "architecture" and corresponding network id (e.g. evm.chainId) is required.
-        # Remember defining networks is OPTIONAL, so only provide these only if you want to override defaults.
-        networks:
-          - architecture: evm
-            evm:
-              chainId: 1
-            # Refer to "Failsafe" section for more details.
-            # On network-level "timeout" is applied for the whole lifecycle of the request (including however many retries)
-            failsafe:
-              timeout:
-                duration: 30s
-              retry:
-                maxCount: 3
-                delay: 500ms
-                backoffMaxDelay: 10s
-                backoffFactor: 0.3
-                jitter: 500ms
-              # Defining a "hedge" is highly-recommended on network-level because if upstream A is being slow for
-              # a specific request, it can start a new parallel hedged request to upstream B, for whichever responds faster.
-              hedge:
-                delay: 3000ms
-                maxCount: 2
-              circuitBreaker:
-                failureThresholdCount: 30
-                failureThresholdCapacity: 100
-                halfOpenAfter: 60s
-                successThresholdCount: 8
-                successThresholdCapacity: 10
-          - architecture: evm
-            evm:
-              chainId: 42161
-            failsafe:
-              timeout:
-                duration: 30s
-              retry:
-                maxCount: 5
-                delay: 500ms
-                backoffMaxDelay: 10s
-                backoffFactor: 0.3
-                jitter: 200ms
-              hedge:
-                delay: 1000ms
-                maxCount: 2
-    
-        # Each upstream supports 1 or more networks (chains)
         upstreams:
-          - id: blastapi-chain-42161
-            type: evm
-            endpoint: https://arbitrum-one.blastapi.io/xxxxxxx-xxxxxx-xxxxxxx
-            # Defines which budget to use when hadnling requests of this upstream.
-            rateLimitBudget: global-blast
-            # chainId is optional and will be detected from the endpoint (eth_chainId) but it is recommended to set it explicitly, for faster initialization.
-            evm:
-              chainId: 42161
-            # Which methods must never be sent to this upstream:
-            ignoreMethods:
-              - "alchemy_*"
-              - "eth_traceTransaction"
-            # Refer to "Failsafe" section for more details:
-            failsafe:
-              timeout:
-                duration: 15s
-              retry:
-                maxCount: 2
-                delay: 1000ms
-                backoffMaxDelay: 10s
-                backoffFactor: 0.3
-                jitter: 500ms
-          - id: blastapi-chain-1
-            type: evm
-            endpoint: https://eth-mainnet.blastapi.io/xxxxxxx-xxxxxx-xxxxxxx
-            rateLimitBudget: global-blast
-            evm:
-              chainId: 1
-            failsafe:
-              timeout:
-                duration: 15s
-              retry:
-                maxCount: 2
-                delay: 1000ms
-                backoffMaxDelay: 10s
-                backoffFactor: 0.3
-                jitter: 500ms
-          - id: quiknode-chain-42161
-            type: evm
-            endpoint: https://xxxxxx-xxxxxx.arbitrum-mainnet.quiknode.pro/xxxxxxxxxxxxxxxxxxxxxxxx/
-            rateLimitBudget: global-quicknode
-            # You can disable auto-ignoring unsupported methods, and instead define them explicitly.
-            # This is useful if provider (e.g. dRPC) is not consistent with "unsupported method" responses.
-            autoIgnoreUnsupportedMethods: false
-            # To allow auto-batching requests towards the upstream, use these settings.
-            # Remember if "supportsBatch" is false, you still can send batch requests to eRPC
-            # but they will be sent to upstream as individual requests.
-            jsonRpc:
-              supportsBatch: true
-              batchMaxSize: 10
-              batchMaxWait: 100ms
-            evm:
-              chainId: 42161
-            failsafe:
-              timeout:
-                duration: 15s
-              retry:
-                maxCount: 2
-                delay: 1000ms
-                backoffMaxDelay: 10s
-                backoffFactor: 0.3
-                jitter: 500ms
-    
-            # "id" is a unique identifier to distinguish in logs and metrics.
-          - id: alchemy-multi-chain-example
-            # For certain known providers (such as Alchemy) you use a custom protocol name
-            # which allows a single upstream to import "all chains" supported by that provider.
-            # Note that these chains are hard-coded in the repo, so if they support a new chain eRPC must be updated.
-            endpoint: alchemy://XXXX_YOUR_ALCHEMY_API_KEY_HERE_XXXX
-            rateLimitBudget: global
-            failsafe:
-              timeout:
-                duration: 15s
-              retry:
-                maxCount: 2
-                delay: 1000ms
-                backoffMaxDelay: 10s
-                backoffFactor: 0.3
-                jitter: 500ms
-    
-    # Rate limiter allows you to create "shared" budgets for upstreams.
-    # For example upstream A and B can use the same budget, which means both of them together must not exceed the defined limits.
-    rateLimiters:
-      budgets:
-        - id: default-budget
-          rules:
-            - method: "*"
-              maxCount: 10000
-              period: 1s
-        - id: global-blast
-          rules:
-            - method: "*"
-              maxCount: 1000
-              period: 1s
-        - id: global-quicknode
-          rules:
-            - method: "*"
-              maxCount: 300
-              period: 1s
-        - id: frontend-budget
-          rules:
-            - method: "*"
-              maxCount: 500
-              period: 1s
+          - endpoint: alchemy://XXXXXXXXXXX
 
-# - HTTP port for erpc interface
+# - HTTP port for erpc
 httpPort: 4000
+
+# - Metrics port for erpc
+metricsPort: 4001
 
 # -- Extra args for the erpc container
 extraArgs: []
@@ -418,16 +250,12 @@ serviceMonitor:
 postgresql:
   # -- If enabled a postgres chart will be deployed as a dependency
   name: "{{ .Release.Name }}-postgresql"
-  enabled: true
-  image:
-    registry: docker.io
-    repository: bitnami/postgresql
-    tag: 15.3.0-debian-11-r7
+  enabled: false
   pullPolicy: IfNotPresent
   auth:
     enablePostgresUser: true
     postgresPassword: postgres
-    database: erpc
+    database: rpc_cache
     username: postgres
     password: postgres
   primary:

--- a/charts/erpc/values.yaml
+++ b/charts/erpc/values.yaml
@@ -24,13 +24,6 @@ config: |
       evmJsonRpcCache:
         driver: memory
 
-        ### example postgres configs ###
-        # driver: postgresql
-        # postgresql:
-        #   connectionUri: >-
-        #     postgres://YOUR_USERNAME_HERE:YOUR_PASSWORD_HERE@{{ .Release.Name }}-postgresql:5432/rpc_cache
-        #   table: rpc_cache
-
     server:
       httpHostV4: "0.0.0.0"
       listenV6: true
@@ -246,21 +239,3 @@ serviceMonitor:
   scrapeTimeout: 30s
   # -- ServiceMonitor relabelings
   relabelings: []
-
-postgresql:
-  # -- If enabled a postgres chart will be deployed as a dependency
-  name: "{{ .Release.Name }}-postgresql"
-  enabled: false
-  pullPolicy: IfNotPresent
-  auth:
-    enablePostgresUser: true
-    postgresPassword: postgres
-    database: rpc_cache
-    username: postgres
-    password: postgres
-  primary:
-    extendedConfiguration: |
-      max_connections = 1024
-  persistence:
-    enabled: true
-    size: 8Gi

--- a/charts/erpc/values.yaml
+++ b/charts/erpc/values.yaml
@@ -125,11 +125,11 @@ resources: {}
 
 # -- The security context for pods
 # @default -- See `values.yaml`
-securityContext: {}
-#  fsGroup: 10001
-#  runAsGroup: 10001
-#  runAsNonRoot: true
-#  runAsUser: 10001
+securityContext:
+  fsGroup: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
 
 # -- The security context for containers
 # @default -- See `values.yaml`


### PR DESCRIPTION
Adds the [erpc](https://github.com/erpc/erpc) chart and closes #337 

## A few things i'd love to get some feedback on

I based my implementation and the relative config defaults on the [railway-deployment](https://github.com/erpc/railway-deployment) for erpc. I'm not a fan of having the config (which contains remote RPC apikeys) be stored in a configmap, but from how they use gotemplate to load env variables into the config file i assume erpc doesnt support config overrides from environment variables.

The [prepackaged docker image by erpc](https://github.com/erpc/erpc/blob/main/Dockerfile) is hardcoded to run as root. It's fairly easy to change that with a new Dockerfile but we would have to rehost the image on another registry and keep it updated. Not sure on what the policies are for that stuff, but i'm open to discuss

I didnt include postgres or prometheus/grafana since they arent a requirement (nor the default config) and people can just deploy those with the relative charts/operators.