### PR TITLE
Update GitHub Actions to use pinned hashes

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 # v4
 
       - name: Check for typos
-        uses: crate-ci/typos@0fa392de4a080a8f22469c05415090ee3addf4fb # v1.28.4
+        uses: crate-ci/typos@0fa392de4a080a8f22469c05415090ee3addf4fb # 0fa392d # v1.28.4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 # v4
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256 # v4
         with:
           version: v3.16.2
 
@@ -32,7 +32,7 @@ jobs:
           helm repo add ethpandaops https://ethpandaops.github.io/ethereum-helm-charts
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0 # v1.6.0
         with:
           charts_dir: charts
           skip_existing: true

--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 # v4
         with:
           fetch-depth: 0
 
@@ -18,20 +18,20 @@ jobs:
         run: git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256 # v4
         with:
           version: v3.16.2
 
       - name: Setup Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0 # v5
         with:
           python-version: 3.12
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1 # v3.0.1
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1 # v2.6.1
         with:
           version: "v3.11.0"
 
@@ -50,7 +50,7 @@ jobs:
           --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0 # v1.10.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/test-ethereum-node.yaml
+++ b/.github/workflows/test-ethereum-node.yaml
@@ -18,7 +18,7 @@ jobs:
         network: [sepolia, mainnet]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 # v4
         with:
           fetch-depth: 0
 
@@ -26,19 +26,19 @@ jobs:
         run: git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256 # v4
         with:
           version: v3.16.2
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0 # v5
         with:
           python-version: 3.12
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1 # v3.0.1
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1 # v2.6.1
         with:
           version: "v3.11.0"
 
@@ -57,7 +57,7 @@ jobs:
           --charts charts/ethereum-node
 
       - name: Create kind cluster
-        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0
+        uses: helm/kind-action@0025e74a8c7512023d06dc019c617aa3cf561fde # v1.10.0 # v1.10.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.