### PR TITLE
Update github actions dependencies to show full versions in comment

### DIFF
--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check for typos
-        uses: crate-ci/typos@0fa392de4a080a8f22469c05415090ee3addf4fb # v1.28.4
+        uses: crate-ci/typos@0fa392de4a080a8f22469c05415090ee3addf4fb # 0fa392d

--- a/.github/workflows/check-typos.yaml
+++ b/.github/workflows/check-typos.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Check for typos
-        uses: crate-ci/typos@0fa392de4a080a8f22469c05415090ee3addf4fb # 0fa392d
+        uses: crate-ci/typos@7bc041cbb7ca9167c9e0e4ccbb26f48eb0f9d4e0 # v1.30.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256
         with:
           version: v3.16.2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.16.2
 

--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -18,7 +18,7 @@ jobs:
         run: git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.16.2
 

--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -10,7 +10,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -18,12 +18,12 @@ jobs:
         run: git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256
         with:
           version: v3.16.2
 
       - name: Setup Python
-        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/test-ethereum-node.yaml
+++ b/.github/workflows/test-ethereum-node.yaml
@@ -18,7 +18,7 @@ jobs:
         network: [sepolia, mainnet]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
@@ -26,11 +26,11 @@ jobs:
         run: git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # v4
+        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256
         with:
           version: v3.16.2
 
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5
+      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 # v5.4.0
         with:
           python-version: 3.12
 

--- a/.github/workflows/test-ethereum-node.yaml
+++ b/.github/workflows/test-ethereum-node.yaml
@@ -26,7 +26,7 @@ jobs:
         run: git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@37dd2562cae2f186a3dc13f2bb5d4abe08dbfec4 # 37dd256
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.16.2
 


### PR DESCRIPTION
This PR updates GitHub Actions to use pinned commit hashes for better security.