### PR TITLE
chore(deps): enable automatic updates for GitHub Actions via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+   - package-ecosystem: github-actions
+     directory: /
+     schedule:
+        interval: monthly
+     groups:
+        actions:
+           patterns:
+              - '*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,18 @@
-version: 2
 updates:
-   - package-ecosystem: github-actions
-     directory: /
-     schedule:
-        interval: monthly
-     groups:
-        actions:
-           patterns:
-              - '*'
+- directory: /
+  groups:
+    actions:
+      patterns:
+      - '*'
+  package-ecosystem: github-actions
+  schedule:
+    interval: monthly
+- directory: /
+  groups:
+    actions:
+      patterns:
+      - '*'
+  package-ecosystem: github-actions
+  schedule:
+    interval: weekly
+version: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,12 @@ updates:
   package-ecosystem: github-actions
   schedule:
     interval: weekly
+- directory: /
+  groups:
+    actions:
+      patterns:
+      - '*'
+  package-ecosystem: github-actions
+  schedule:
+    interval: weekly
 version: 2


### PR DESCRIPTION

### Dependabot automatic updates
This PR enables automatic updates for GitHub Actions via [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

Dependabot will periodically check for new versions of the actions and create a PR to update the version used in the repository.

This should help keeping your GitHub Actions up to date with the latest versions of the actions.

#### How was this detected and generated?
This PR was generated using [ethpandaops/github-actions-checker](https://github.com/ethpandaops/github-actions-checker).
