### PR TITLE
feat(charts/reth): split out default command args template

### DIFF
--- a/charts/reth/Chart.yaml
+++ b/charts/reth/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://github.com/paradigmxyz/reth/raw/main/assets/reth.jpg
 sources:
   - https://github.com/paradigmxyz/reth/
 type: application
-version: 0.0.15
+version: 0.0.16
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/reth/README.md
+++ b/charts/reth/README.md
@@ -1,7 +1,7 @@
 
 # reth
 
-![Version: 0.0.15](https://img.shields.io/badge/Version-0.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.16](https://img.shields.io/badge/Version-0.0.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implementation that is focused on being user-friendly, highly modular, as well as being fast and efficient. Reth is an Execution Layer (EL) and is compatible with all Ethereum Consensus Layer (CL) implementations that support the Engine API. It is originally built and driven forward by Paradigm, and is licensed under the Apache and MIT licenses.
 
@@ -20,6 +20,7 @@ Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implem
 | authPort | int | `8551` | Engine Port (Auth Port) |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customCommand | list | `[]` | Legacy way of overwriting the default command. You may prefer to change defaultCommandTemplate instead. |
+| defaultCommandArgsTemplate | string | See `values.yaml` | Template used for the default command arguments |
 | defaultCommandTemplate | string | See `values.yaml` | Template used for the default command |
 | extraArgs | list | `[]` | Extra args for the reth container |
 | extraContainerPorts | list | `[]` | Additional ports for the main container |

--- a/charts/reth/values.yaml
+++ b/charts/reth/values.yaml
@@ -32,40 +32,45 @@ defaultCommandTemplate: |
     . /env/init-nodeport;
   {{- end }}
     exec /usr/local/bin/reth node
-    --datadir=/data
-    --config=/data/config.toml
+    {{- tpl .Values.defaultCommandArgsTemplate . | nindent 4 }}
+
+# -- Template used for the default command arguments
+# @default -- See `values.yaml`
+defaultCommandArgsTemplate: |
+  --datadir=/data
+  --config=/data/config.toml
   {{- if .Values.p2pNodePort.enabled }}
-    {{- if not (contains "--nat=" (.Values.extraArgs | join ",")) }}
-    --nat=extip:$EXTERNAL_IP
-    {{- end }}
-    {{- if not (contains "--port=" (.Values.extraArgs | join ",")) }}
-    --port=$EXTERNAL_PORT
-    {{- end }}
-  {{- else }}
-    {{- if not (contains "--nat=" (.Values.extraArgs | join ",")) }}
-    --nat=extip:$(POD_IP)
-    {{- end }}
-    {{- if not (contains "--port=" (.Values.extraArgs | join ",")) }}
-    --port={{ include "reth.p2pPort" . }}
-    {{- end }}
+  {{- if not (contains "--nat=" (.Values.extraArgs | join ",")) }}
+  --nat=extip:$EXTERNAL_IP
   {{- end }}
-    --http
-    --http.addr=0.0.0.0
-    --http.port={{ .Values.httpPort }}
-    --http.corsdomain=*
-    --ws
-    --ws.addr=0.0.0.0
-    --ws.port={{ .Values.wsPort }}
-    --ws.origins=*
-    --authrpc.jwtsecret=/data/jwt.hex
-    --authrpc.addr=0.0.0.0
-    --authrpc.port={{ .Values.authPort }}
-    --log.file.directory=/data/logs
+  {{- if not (contains "--port=" (.Values.extraArgs | join ",")) }}
+  --port=$EXTERNAL_PORT
+  {{- end }}
+  {{- else }}
+  {{- if not (contains "--nat=" (.Values.extraArgs | join ",")) }}
+  --nat=extip:$(POD_IP)
+  {{- end }}
+  {{- if not (contains "--port=" (.Values.extraArgs | join ",")) }}
+  --port={{ include "reth.p2pPort" . }}
+  {{- end }}
+  {{- end }}
+  --http
+  --http.addr=0.0.0.0
+  --http.port={{ .Values.httpPort }}
+  --http.corsdomain=*
+  --ws
+  --ws.addr=0.0.0.0
+  --ws.port={{ .Values.wsPort }}
+  --ws.origins=*
+  --authrpc.jwtsecret=/data/jwt.hex
+  --authrpc.addr=0.0.0.0
+  --authrpc.port={{ .Values.authPort }}
+  --log.file.directory=/data/logs
   {{- if .Values.metricsPort }}
-    --metrics=0.0.0.0:{{ .Values.metricsPort }}
+  --metrics=0.0.0.0:{{ .Values.metricsPort }}
   {{- end }}
   {{- range .Values.extraArgs }}
-    {{ tpl . $ }}
+  {{ tpl . $ }}
   {{- end }}
 
 # -- Legacy way of overwriting the default command. You may prefer to change defaultCommandTemplate instead.


### PR DESCRIPTION
Small change to make it easier to reuse reth args when extending reth functionality or deployments.

For example, when using vault for secrets via the injector agent:

```
defaultCommandTemplate: |
  - sh
  - -ac
  - >
    . /vault/secrets/reth-secrets;
    exec /usr/local/bin/reth node
    {{- tpl .Values.defaultCommandArgsTemplate . | nindent 4 }}
```

No need to copy/paste and update all the reth args 👍🏻

Thoughts?