### PR TITLE
Fix broken link to Blockscout environment variables documentation

### DIFF
--- a/charts/blockscout/README.md
+++ b/charts/blockscout/README.md
@@ -25,7 +25,7 @@ BlockScout provides a comprehensive, easy-to-use interface for users to view, co
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity configuration for pods |
 | annotations | object | `{}` | Annotations for the StatefulSet |
-| config | object | See `values.yaml` | Config file https://docs.blockscout.com/for-developers/information-and-settings/env-variables |
+| config | object | See `values.yaml` | Config file https://docs.blockscout.com/setup/env-variables/backend-env-variables |
 | containerSecurityContext | object | See `values.yaml` | The security context for containers |
 | customArgs | list | `[]` | Custom args for the blockscout container |
 | customCommand | list | `[]` | Command replacement for the blockscout container |


### PR DESCRIPTION
Replaced the outdated link to Blockscout environment variables in the Blockscout Helm chart README with the current, working URL:
https://docs.blockscout.com/setup/env-variables/backend-env-variables
This ensures users can access up-to-date information on configuring environment variables for Blockscout.