### PR TITLE
fix: correct init container ordering for devnet support

### DIFF
--- a/charts/besu/Chart.yaml
+++ b/charts/besu/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://launchpad.ethereum.org/static/media/hyperledger-besu-circle.b96368
 sources:
   - https://github.com/hyperledger/besu
 type: application
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/besu/README.md
+++ b/charts/besu/README.md
@@ -1,7 +1,7 @@
 
 # besu
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An Ethereum execution layer client designed to be enterprise-friendly for both public and private, permissioned network use cases. Besu is written in Java and released under the Apache 2.0 Licence.
 

--- a/charts/besu/templates/statefulset.yaml
+++ b/charts/besu/templates/statefulset.yaml
@@ -67,6 +67,9 @@ spec:
             - name: env-nodeport
               mountPath: /env
       {{- end }}
+      {{- if .Values.devnet.enabled }}
+        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
+      {{- end }}
       {{- if .Values.initChownData.enabled }}
         - name: init-chown-data
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
@@ -80,9 +83,6 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: "/data"
-      {{- end }}
-      {{- if .Values.devnet.enabled }}
-        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://pbs.twimg.com/profile_images/1420080204148576274/-4OFIs2x_400x400.
 sources:
   - https://github.com/ledgerwatch/erigon
 type: application
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/erigon/README.md
+++ b/charts/erigon/README.md
@@ -1,7 +1,7 @@
 
 # erigon
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented toward speed and disk‐space efficiency. Erigon is a completely re-architected implementation of Ethereum, currently written in Go but with implementations in other languages planned. Erigon's goal is to provide a faster, more modular, and more optimized implementation of Ethereum.
 

--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -68,6 +68,9 @@ spec:
             - name: env-nodeport
               mountPath: /env
       {{- end }}
+      {{- if .Values.devnet.enabled }}
+        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
+      {{- end }}
       {{- if .Values.initChownData.enabled }}
         - name: init-chown-data
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
@@ -81,9 +84,6 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: "/data"
-      {{- end }}
-      {{- if .Values.devnet.enabled }}
-        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/ethereumjs/Chart.yaml
+++ b/charts/ethereumjs/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://user-images.githubusercontent.com/47108/78779352-d0839500-796a-11e
 sources:
   - https://github.com/ethereumjs/ethereumjs-monorepo
 type: application
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/ethereumjs/README.md
+++ b/charts/ethereumjs/README.md
@@ -1,7 +1,7 @@
 
 # ethereumjs
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 The EthereumJS Client is an Ethereum Execution Client (similar to go-ethereum or Nethermind) written in TypeScript/JavaScript, the non-Smart-Contract language Ethereum dApp developers are most familiar with. It is targeted to be a client for research and development and not meant to be used in production on mainnet for the foreseeable future (out of resource and security considerations).
 

--- a/charts/ethereumjs/templates/statefulset.yaml
+++ b/charts/ethereumjs/templates/statefulset.yaml
@@ -67,6 +67,9 @@ spec:
             - name: env-nodeport
               mountPath: /env
       {{- end }}
+      {{- if .Values.devnet.enabled }}
+        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
+      {{- end }}
       {{- if .Values.initChownData.enabled }}
         - name: init-chown-data
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
@@ -80,9 +83,6 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: "/data"
-      {{- end }}
-      {{- if .Values.devnet.enabled }}
-        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/geth/Chart.yaml
+++ b/charts/geth/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://launchpad.ethereum.org/static/media/gethereum-mascot-circle.75cbd3
 sources:
   - https://github.com/ethereum/go-ethereum
 type: application
-version: 1.1.0
+version: 1.1.1
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/geth/README.md
+++ b/charts/geth/README.md
@@ -1,7 +1,7 @@
 
 # geth
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Go Ethereum (Geth for short) is one of the original implementations of the Ethereum protocol. Currently, it is the most widespread client with the biggest user base and variety of tooling for users and developers. It is written in Go, fully open source and licensed under the GNU LGPL v3
 

--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -68,6 +68,9 @@ spec:
             - name: env-nodeport
               mountPath: /env
       {{- end }}
+      {{- if .Values.devnet.enabled }}
+        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
+      {{- end }}
       {{- if .Values.initChownData.enabled }}
         - name: init-chown-data
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
@@ -81,9 +84,6 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: "/data"
-      {{- end }}
-      {{- if .Values.devnet.enabled }}
-        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/grandine/Chart.yaml
+++ b/charts/grandine/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://github.com/sifraitech/grandine/blob/master/gui.png
 sources:
   - https://github.com/sifraitech/grandine
 type: application
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/grandine/README.md
+++ b/charts/grandine/README.md
@@ -1,7 +1,7 @@
 
 # grandine
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A currently closed source, but hopefully soon to be open-source Ethereum Consensus layer client, written in Rust.
 

--- a/charts/grandine/templates/statefulset.yaml
+++ b/charts/grandine/templates/statefulset.yaml
@@ -67,6 +67,9 @@ spec:
             - name: env-nodeport
               mountPath: /env
       {{- end }}
+      {{- if .Values.devnet.enabled }}
+        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
+      {{- end }}
       {{- if .Values.initChownData.enabled }}
         - name: init-chown-data
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
@@ -80,9 +83,6 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: "/data"
-      {{- end }}
-      {{- if .Values.devnet.enabled }}
-        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/lighthouse/Chart.yaml
+++ b/charts/lighthouse/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/lighthouse-circle.e0b82d14.png
 sources:
   - https://github.com/sigp/lighthouse
 type: application
-version: 1.1.6
+version: 1.1.7
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -1,7 +1,7 @@
 
 # lighthouse
 
-![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.7](https://img.shields.io/badge/Version-1.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum 2.0 client, written in Rust
 

--- a/charts/lighthouse/templates/statefulset.yaml
+++ b/charts/lighthouse/templates/statefulset.yaml
@@ -67,6 +67,9 @@ spec:
             - name: env-nodeport
               mountPath: /env
       {{- end }}
+      {{- if .Values.devnet.enabled }}
+        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
+      {{- end }}
       {{- if .Values.initChownData.enabled }}
         - name: init-chown-data
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
@@ -80,9 +83,6 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: "/data"
-      {{- end }}
-      {{- if .Values.devnet.enabled }}
-        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/reth/Chart.yaml
+++ b/charts/reth/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://github.com/paradigmxyz/reth/raw/main/assets/reth.jpg
 sources:
   - https://github.com/paradigmxyz/reth/
 type: application
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/reth/README.md
+++ b/charts/reth/README.md
@@ -1,7 +1,7 @@
 
 # reth
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implementation that is focused on being user-friendly, highly modular, as well as being fast and efficient. Reth is an Execution Layer (EL) and is compatible with all Ethereum Consensus Layer (CL) implementations that support the Engine API. It is originally built and driven forward by Paradigm, and is licensed under the Apache and MIT licenses.
 

--- a/charts/reth/templates/statefulset.yaml
+++ b/charts/reth/templates/statefulset.yaml
@@ -67,6 +67,9 @@ spec:
             - name: env-nodeport
               mountPath: /env
       {{- end }}
+      {{- if .Values.devnet.enabled }}
+        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
+      {{- end }}
       {{- if .Values.initChownData.enabled }}
         - name: init-chown-data
           image: "{{ .Values.initChownData.image.repository }}:{{ .Values.initChownData.image.tag }}"
@@ -80,9 +83,6 @@ spec:
           volumeMounts:
             - name: storage
               mountPath: "/data"
-      {{- end }}
-      {{- if .Values.devnet.enabled }}
-        {{- tpl (toYaml .Values.devnet.initContainer | nindent 8) $ }}
       {{- end }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Summary
- Fixed init container ordering issue where `init-chown-data` was running before devnet init containers
- The devnet init containers create files as root, so `init-chown-data` must run after them to fix permissions
- This resolves permission denied errors when running with devnet enabled

## Changes
Fixed init container ordering in the following charts by moving `init-chown-data` to run AFTER devnet init containers:
- ✅ geth (1.1.0 -> 1.1.1)
- ✅ besu (1.1.0 -> 1.1.1)  
- ✅ erigon (1.1.0 -> 1.1.1)
- ✅ ethereumjs (0.1.0 -> 0.1.1)
- ✅ reth (0.1.0 -> 0.1.1)
- ✅ grandine (0.2.0 -> 0.2.1)
- ✅ lighthouse (1.1.6 -> 1.1.7)

Note: nethermind, lodestar, prysm, and teku already had the correct ordering.
