### PR TITLE
chore(ethereum-node): update child chart versions

### DIFF
--- a/charts/ethereum-node/Chart.lock
+++ b/charts/ethereum-node/Chart.lock
@@ -1,28 +1,28 @@
 dependencies:
 - name: besu
   repository: https://ethpandaops.github.io/ethereum-helm-charts
-  version: 1.1.0
+  version: 1.1.1
 - name: erigon
   repository: https://ethpandaops.github.io/ethereum-helm-charts
-  version: 1.1.0
+  version: 1.1.1
 - name: ethereumjs
   repository: https://ethpandaops.github.io/ethereum-helm-charts
-  version: 0.1.0
+  version: 0.1.1
 - name: geth
   repository: https://ethpandaops.github.io/ethereum-helm-charts
-  version: 1.1.0
+  version: 1.1.1
 - name: nethermind
   repository: https://ethpandaops.github.io/ethereum-helm-charts
   version: 1.1.0
 - name: reth
   repository: https://ethpandaops.github.io/ethereum-helm-charts
-  version: 0.1.0
+  version: 0.1.1
 - name: grandine
   repository: https://ethpandaops.github.io/ethereum-helm-charts
-  version: 0.2.0
+  version: 0.2.1
 - name: lighthouse
   repository: https://ethpandaops.github.io/ethereum-helm-charts
-  version: 1.1.6
+  version: 1.1.7
 - name: lodestar
   repository: https://ethpandaops.github.io/ethereum-helm-charts
   version: 1.2.0
@@ -44,5 +44,5 @@ dependencies:
 - name: tracoor-agent
   repository: https://ethpandaops.github.io/ethereum-helm-charts
   version: 0.0.1
-digest: sha256:290c349597b7e7c7b339bd6e41709577525fb42d50184da60c62ce0cc692a05a
-generated: "2025-08-08T11:42:32.14761+10:00"
+digest: sha256:b3b82582743ccabf47bad3aa364db8c9cd94d81427b5c0ef3631cf9932613132
+generated: "2025-08-08T13:45:36.825776+10:00"

--- a/charts/ethereum-node/Chart.yaml
+++ b/charts/ethereum-node/Chart.yaml
@@ -8,26 +8,26 @@ icon: https://avatars.githubusercontent.com/u/6250754?s=200&v=4
 sources:
   - https://github.com/ethpandaops/ethereum-helm-charts
 type: application
-version: 0.2.0
+version: 0.2.1
 maintainers:
   - name: skylenet
     email: rafael@skyle.net
 
 dependencies:
 - name: besu
-  version: "1.1.0"
+  version: "1.1.1"
   repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   condition: besu.enabled
 - name: erigon
-  version: "1.1.0"
+  version: "1.1.1"
   repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   condition: erigon.enabled
 - name: ethereumjs
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   condition: ethereumjs.enabled
 - name: geth
-  version: "1.1.0"
+  version: "1.1.1"
   repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   condition: geth.enabled
 - name: nethermind
@@ -35,16 +35,16 @@ dependencies:
   repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   condition: nethermind.enabled
 - name: reth
-  version: "0.1.0"
+  version: "0.1.1"
   repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   condition: reth.enabled
 
 - name: grandine
-  version: "0.2.0"
+  version: "0.2.1"
   repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   condition: grandine.enabled
 - name: lighthouse
-  version: "1.1.6"
+  version: "1.1.7"
   repository: "https://ethpandaops.github.io/ethereum-helm-charts"
   condition: lighthouse.enabled
 - name: lodestar

--- a/charts/ethereum-node/README.md
+++ b/charts/ethereum-node/README.md
@@ -1,7 +1,7 @@
 
 # ethereum-node
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 This chart acts as an umbrella chart and allows to run a ethereum execution and consensus layer client. It's also able to deploy optional monitoring applications.
 
@@ -14,18 +14,18 @@ This chart acts as an umbrella chart and allows to run a ethereum execution and 
 ## Subcharts
 | Repository | Name | Version |
 |------------|------|---------|
-| https://ethpandaops.github.io/ethereum-helm-charts | besu | 1.1.0 |
-| https://ethpandaops.github.io/ethereum-helm-charts | erigon | 1.1.0 |
+| https://ethpandaops.github.io/ethereum-helm-charts | besu | 1.1.1 |
+| https://ethpandaops.github.io/ethereum-helm-charts | erigon | 1.1.1 |
 | https://ethpandaops.github.io/ethereum-helm-charts | ethereum-metrics-exporter | 0.2.0 |
-| https://ethpandaops.github.io/ethereum-helm-charts | ethereumjs | 0.1.0 |
-| https://ethpandaops.github.io/ethereum-helm-charts | geth | 1.1.0 |
-| https://ethpandaops.github.io/ethereum-helm-charts | grandine | 0.2.0 |
-| https://ethpandaops.github.io/ethereum-helm-charts | lighthouse | 1.1.6 |
+| https://ethpandaops.github.io/ethereum-helm-charts | ethereumjs | 0.1.1 |
+| https://ethpandaops.github.io/ethereum-helm-charts | geth | 1.1.1 |
+| https://ethpandaops.github.io/ethereum-helm-charts | grandine | 0.2.1 |
+| https://ethpandaops.github.io/ethereum-helm-charts | lighthouse | 1.1.7 |
 | https://ethpandaops.github.io/ethereum-helm-charts | lodestar | 1.2.0 |
 | https://ethpandaops.github.io/ethereum-helm-charts | nethermind | 1.1.0 |
 | https://ethpandaops.github.io/ethereum-helm-charts | nimbus | 1.2.0 |
 | https://ethpandaops.github.io/ethereum-helm-charts | prysm | 1.2.0 |
-| https://ethpandaops.github.io/ethereum-helm-charts | reth | 0.1.0 |
+| https://ethpandaops.github.io/ethereum-helm-charts | reth | 0.1.1 |
 | https://ethpandaops.github.io/ethereum-helm-charts | teku | 1.2.0 |
 | https://ethpandaops.github.io/ethereum-helm-charts | tracoor-agent | 0.0.1 |
 | https://ethpandaops.github.io/ethereum-helm-charts | xatu-sentry | 0.0.8 |


### PR DESCRIPTION
## Summary
- Updated child chart versions in ethereum-node to include init container ordering fixes from #392
- Bumped ethereum-node version from 0.2.0 to 0.2.1

🤖 Generated with [Claude Code](https://claude.ai/code)