### PR TITLE
fix(prysm): update PodDisruptionBudget to policy/v1 API

### DIFF
--- a/charts/prysm/templates/poddisruptionbudget.yaml
+++ b/charts/prysm/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.podDisruptionBudget }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "prysm.fullname" . }}


### PR DESCRIPTION
## Summary
- Updates PodDisruptionBudget from deprecated `policy/v1beta1` to `policy/v1`
- The v1beta1 API was deprecated in Kubernetes 1.21 and removed in 1.25

## Changes
- `charts/prysm/templates/poddisruptionbudget.yaml`: Updated apiVersion from `policy/v1beta1` to `policy/v1`