### PR TITLE
fix(xatu-cbt-api): fix command, config path, and probe ports

### DIFF
--- a/charts/xatu-cbt-api/Chart.yaml
+++ b/charts/xatu-cbt-api/Chart.yaml
@@ -3,7 +3,7 @@ name: xatu-cbt-api
 description: API server for Xatu CBT
 home: https://github.com/ethpandaops/xatu-cbt-api
 type: application
-version: 0.0.11
+version: 0.0.12
 maintainers:
   - name: samcm
     email: sam.calder-mason@ethereum.org

--- a/charts/xatu-cbt-api/README.md
+++ b/charts/xatu-cbt-api/README.md
@@ -1,7 +1,7 @@
 
 # xatu-cbt-api
 
-![Version: 0.0.11](https://img.shields.io/badge/Version-0.0.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.12](https://img.shields.io/badge/Version-0.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 API server for Xatu CBT
 

--- a/charts/xatu-cbt-api/templates/deployment.yaml
+++ b/charts/xatu-cbt-api/templates/deployment.yaml
@@ -53,9 +53,7 @@ spec:
         {{- if gt (len .Values.customCommand) 0 }}
           {{- toYaml .Values.customCommand | nindent 12}}
         {{- else }}
-          - "/xatu-cbt-api"
-          - "server"
-          - --config=/config.yaml
+          - "/app/server"
           {{- if gt (len .Values.args) 0 }}
           {{- toYaml .Values.args | nindent 12}}
           {{- end }}
@@ -68,7 +66,7 @@ spec:
           {{- toYaml .Values.containerSecurityContext | nindent 12 }}
         volumeMounts:
           - name: config
-            mountPath: "/config.yaml"
+            mountPath: "/app/config.yaml"
             subPath: config.yaml
             readOnly: true
           {{- if .Values.extraVolumeMounts }}

--- a/charts/xatu-cbt-api/values.yaml
+++ b/charts/xatu-cbt-api/values.yaml
@@ -96,7 +96,7 @@ livenessProbe:
   custom: false
   customProbe: {}
   tcp:
-    port: metrics
+    port: http
     initialDelaySeconds: 60
     periodSeconds: 120
 
@@ -108,7 +108,7 @@ readinessProbe:
   custom: false
   customProbe: {}
   tcp:
-    port: metrics
+    port: http
     initialDelaySeconds: 10
     periodSeconds: 10
 


### PR DESCRIPTION
- Fixed default command to use correct binary path /app/server
- Fixed config mount path from /config.yaml to /app/config.yaml
- Fixed liveness and readiness probe ports from 'metrics' to 'http'
- Bumped chart version to 0.0.12