### PR TITLE
feat(lighthouse): decouple p2p listen port from NodePort

### DIFF
--- a/charts/lighthouse/Chart.yaml
+++ b/charts/lighthouse/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/lighthouse-circle.e0b82d14.png
 sources:
   - https://github.com/sigp/lighthouse
 type: application
-version: 1.1.8
+version: 1.1.9
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -1,7 +1,7 @@
 
 # lighthouse
 
-![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.9](https://img.shields.io/badge/Version-1.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum 2.0 client, written in Rust
 
@@ -63,11 +63,13 @@ An open-source Ethereum 2.0 client, written in Rust
 | mode | string | `"beacon"` | Mode can be 'beacon','validator' or 'bootnode' |
 | nameOverride | string | `""` | Overrides the chart's name |
 | nodeSelector | object | `{}` | Node selector for pods |
+| p2pNodePort.advertisedPort | string | `nil` | Optional ENR advertised TCP/UDP port override when p2pNodePort.enabled=true. Leave null to advertise the discovered NodePort. |
 | p2pNodePort.enabled | bool | `false` | Expose P2P port via NodePort |
 | p2pNodePort.initContainer.image.pullPolicy | string | `"IfNotPresent"` | Container pull policy |
 | p2pNodePort.initContainer.image.repository | string | `"lachlanevenson/k8s-kubectl"` | Container image to fetch nodeport information |
 | p2pNodePort.initContainer.image.tag | string | `"v1.25.4"` | Container tag |
 | p2pNodePort.port | int | `31000` | NodePort to be used |
+| p2pNodePort.useNodePortForContainerPort | bool | `true` | Keep backward-compatible behavior by binding Lighthouse to NodePort when enabled. Set to false to keep Lighthouse listening on p2pPort and use NodePort service mapping only. |
 | p2pPort | int | `9000` | P2P Port |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access mode for the volume claim template |
 | persistence.annotations | object | `{}` | Annotations for volume claim template |
@@ -138,6 +140,21 @@ replicas: 1
 p2pNodePort:
   enabled: true
   port: 31000
+```
+
+## Exposing NodePort while keeping Lighthouse on canonical port 9000
+
+Use this when your router/NAT exposes public `9000` but Kubernetes NodePort must stay in `30000-32767`.
+In this mode Lighthouse keeps listening on `p2pPort` while NodePort maps traffic to that container port.
+
+```yaml
+p2pPort: 9000
+
+p2pNodePort:
+  enabled: true
+  port: 30304
+  useNodePortForContainerPort: false
+  advertisedPort: 9000
 ```
 
 ## Validator node targeting a beacon node service

--- a/charts/lighthouse/README.md.gotmpl
+++ b/charts/lighthouse/README.md.gotmpl
@@ -41,6 +41,21 @@ p2pNodePort:
   port: 31000
 ```
 
+## Exposing NodePort while keeping Lighthouse on canonical port 9000
+
+Use this when your router/NAT exposes public `9000` but Kubernetes NodePort must stay in `30000-32767`.
+In this mode Lighthouse keeps listening on `p2pPort` while NodePort maps traffic to that container port.
+
+```yaml
+p2pPort: 9000
+
+p2pNodePort:
+  enabled: true
+  port: 30304
+  useNodePortForContainerPort: false
+  advertisedPort: 9000
+```
+
 ## Validator node targeting a beacon node service
 
 This example runs a validator on the holesky network that targets a pre-existing `lighthouse-beacon` service:

--- a/charts/lighthouse/templates/_helpers.tpl
+++ b/charts/lighthouse/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "lighthouse.p2pPort" -}}
-{{- if .Values.p2pNodePort.enabled }}
+{{- if and .Values.p2pNodePort.enabled .Values.p2pNodePort.useNodePortForContainerPort }}
 {{- print .Values.p2pNodePort.port }}
 {{- else }}
 {{- print .Values.p2pPort }}

--- a/charts/lighthouse/templates/service.p2p.nodeport.yaml
+++ b/charts/lighthouse/templates/service.p2p.nodeport.yaml
@@ -16,12 +16,12 @@ spec:
       port: {{ include "lighthouse.p2pPort" $ }}
       protocol: TCP
       targetPort: p2p-tcp
-      nodePort: {{ include "lighthouse.p2pPort" $ }}
+      nodePort: {{ .Values.p2pNodePort.port }}
     - name: p2p-udp
       port: {{ include "lighthouse.p2pPort" $ }}
       protocol: UDP
       targetPort: p2p-udp
-      nodePort: {{ include "lighthouse.p2pPort" $ }}
+      nodePort: {{ .Values.p2pNodePort.port }}
   selector:
     {{- include "lighthouse.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: "{{ include "lighthouse.fullname" $ }}-0"

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -113,10 +113,18 @@ defaultBeaconCommandTemplate: |
     --enr-address=$EXTERNAL_IP
     {{- end }}
     {{- if not (contains "--enr-tcp-port=" (.Values.extraArgs | join ",")) }}
+    {{- if .Values.p2pNodePort.advertisedPort }}
+    --enr-tcp-port={{ .Values.p2pNodePort.advertisedPort }}
+    {{- else }}
     --enr-tcp-port=$EXTERNAL_PORT
     {{- end }}
+    {{- end }}
     {{- if not (contains "--enr-udp-port=" (.Values.extraArgs | join ",")) }}
+    {{- if .Values.p2pNodePort.advertisedPort }}
+    --enr-udp-port={{ .Values.p2pNodePort.advertisedPort }}
+    {{- else }}
     --enr-udp-port=$EXTERNAL_PORT
+    {{- end }}
     {{- end }}
   {{- else }}
     {{- if not (contains "--enr-address=" (.Values.extraArgs | join ",")) }}
@@ -185,7 +193,11 @@ defaultBootnodeCommandTemplate: |
     {{ . }}
   {{- end }}
   {{- if .Values.p2pNodePort.enabled }}
+    {{- if .Values.p2pNodePort.advertisedPort }}
+    --enr-port={{ .Values.p2pNodePort.advertisedPort }}
+    {{- else }}
     --enr-port=$EXTERNAL_PORT
+    {{- end }}
     --enr-address=$EXTERNAL_IP
   {{- else }}
     --enr-port={{ include "lighthouse.p2pPort" . }}
@@ -204,6 +216,12 @@ p2pNodePort:
   enabled: false
   # -- NodePort to be used
   port: 31000
+  # -- Keep backward-compatible behavior by binding Lighthouse to NodePort when enabled.
+  # Set to false to keep Lighthouse listening on p2pPort and use NodePort service mapping only.
+  useNodePortForContainerPort: true
+  # -- Optional ENR advertised TCP/UDP port override when p2pNodePort.enabled=true.
+  # Leave null to advertise the discovered NodePort.
+  advertisedPort: null
   initContainer:
     image:
       # -- Container image to fetch nodeport information


### PR DESCRIPTION
## Summary
- Add an opt-in way to keep Lighthouse listening on `p2pPort` while exposing a different Kubernetes NodePort.
- Add an optional ENR advertised port override for NodePort mode.
- Keep current behavior as default for backward compatibility.

## Motivation
For NAT/router deployments, I want this model:

- Public/router port: `9000`
- Lighthouse container port: `9000`
- Kubernetes NodePort: `30304` (or any valid NodePort)

Today, `p2pNodePort.enabled=true` couples listen port, NodePort, and advertised ENR port. This PR decouples those concerns via values so users don’t need to define a custom Service outside the chart.

## Traffic model

```text
Internet peer
   -> PUBLIC_IP:9000
      -> Router DSTNAT 9000 -> NodeIP:30304
         -> K8s NodePort Service 30304 -> Pod:9000
            -> Lighthouse listens on 9000

ENR advertises: ip=PUBLIC_IP tcp=9000 udp=9000
```

## What changed
- Added `p2pNodePort.useNodePortForContainerPort` (default: `true`)
  - `true` => existing behavior (bind/listen on NodePort value)
  - `false` => bind/listen on `p2pPort`, NodePort only used for Service exposure
- Added `p2pNodePort.advertisedPort` (default: `null`)
  - when set, ENR advertises this port instead of discovered NodePort
- Updated NodePort Service template to use `p2pNodePort.port` explicitly for `nodePort`.
- Updated chart docs and examples.
- Bumped chart version from `1.1.8` to `1.1.9`.

## Example values (decoupled mode)

```yaml
p2pPort: 9000

p2pNodePort:
  enabled: true
  port: 30304
  useNodePortForContainerPort: false
  advertisedPort: 9000
```

## Backward compatibility
- Default behavior is unchanged.
- Existing users with `p2pNodePort.enabled=true` keep current bind/advertise semantics unless they opt in.

## Validation
- `helm lint charts/lighthouse --set-string 'extraArgs[0]=--execution-endpoint=http://localhost:8551'`
- Rendered default NodePort mode and confirmed existing behavior is preserved.
- Rendered decoupled mode and confirmed:
  - container binds `9000`
  - Service NodePort is `30304`
  - ENR tcp/udp advertise `9000`