### PR TITLE
chore(erpc): bump image to 0.0.63

### DIFF
--- a/charts/erpc/Chart.yaml
+++ b/charts/erpc/Chart.yaml
@@ -3,7 +3,7 @@ name: erpc
 description: eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching solution. It is built with read-heavy use-cases in mind such as data indexing and high-load frontend usage.
 home: https://github.com/erpc/erpc
 type: application
-version: 0.0.4
+version: 0.0.5
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/erpc/README.md
+++ b/charts/erpc/README.md
@@ -1,7 +1,7 @@
 
 # erpc
 
-![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.5](https://img.shields.io/badge/Version-0.0.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching solution. It is built with read-heavy use-cases in mind such as data indexing and high-load frontend usage.
 
@@ -26,7 +26,7 @@ eRPC is a fault-tolerant EVM RPC proxy and re-org aware permanent caching soluti
 | httpPort | int | `4000` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | erpc container pull policy |
 | image.repository | string | `"ghcr.io/erpc/erpc"` | erpc container image repository |
-| image.tag | string | `"0.0.49"` | erpc container image tag |
+| image.tag | string | `"0.0.63"` | erpc container image tag |
 | imagePullSecrets | list | `[]` | Image pull secrets for Docker images |
 | ingress.annotations | object | `{}` | Annotations for Ingress |
 | ingress.enabled | bool | `false` | Ingress resource for the HTTP API |

--- a/charts/erpc/values.yaml
+++ b/charts/erpc/values.yaml
@@ -11,7 +11,7 @@ image:
   # -- erpc container image repository
   repository: ghcr.io/erpc/erpc
   # -- erpc container image tag
-  tag: 0.0.49
+  tag: 0.0.63
   # -- erpc container pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary

- Bumps erpc container image from `0.0.49` → `0.0.63`
- Bumps chart `version` from `0.0.4` → `0.0.5`

## Why

Current `0.0.49` is from May 2025 and we're 14 minor versions behind. The problem we saw on `bal-devnet-3` today — erpc round-robining into a stalled `lodestar-besu` upstream and serving 30s+ timeouts for `eth_blockNumber` / `eth_getBalance` / `eth_getTransactionCount` while 14 other upstreams were healthy — is directly addressed by upstream changes in `0.0.63`:

- **0.0.63** (#772): routing rewrite — smoother score-based + round-robin strategy with upstream score granularity and penalty decay. Stalled upstreams get weighted down quickly instead of being selected into timeouts.
- **0.0.63**: JSON-RPC error normalisation now correctly classifies `context cancellation` / `deadline exceeded` — which is exactly what we were seeing in erpc logs for the dead upstream.
- **0.0.62** (#703): idempotent `eth_sendRawTransaction` broadcasting — nice for spamoor-style workloads.

## Config compatibility

Reviewed every release between `0.0.49` and `0.0.63`. The chart's default `config` block only uses:
- `database.evmJsonRpcCache.{connectors,policies}`
- `server.{httpHostV4,listenV6,httpHostV6,httpPort}`
- `metrics.{enabled,hostV4,hostV6,port}`
- `projects[].upstreams[].endpoint`

None of these were affected by breaking changes. The one hard rename — `consensus.required` → `consensus.maxParticipants` in `0.0.54` — does not apply because the chart does not configure a consensus failsafe policy.

Behavioural change worth knowing: since `0.0.61` (#528), erpc returns HTTP 200 for all JSON-RPC responses (errors carried in the body). Any consumer that keys alerts off HTTP status codes will need to switch to the richer Prom labels.

## Test plan

- [ ] `helm lint charts/erpc/`
- [ ] `ct lint --target-branch master` (via `make lint`)
- [ ] Render a template with the default values and verify the image tag
- [ ] Deploy to a devnet and sanity-check `/healthcheck` + a couple of JSON-RPC calls