### PR TITLE
dora: default ranges to {} so dora can parse it

### DIFF
--- a/charts/dora/Chart.yaml
+++ b/charts/dora/Chart.yaml
@@ -3,7 +3,7 @@ name: dora
 description: A Beaconchain explorer is a tool that allows users to view and interact with the data on the Ethereum Beacon Chain. It is similar to a blockchain explorer, which allows users to view data on a blockchain such as the current state of transactions and blocks - but focussed on exploring the beaconchain.
 home: https://github.com/pk910/dora
 type: application
-version: 1.0.8
+version: 1.0.9
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/dora/README.md
+++ b/charts/dora/README.md
@@ -1,7 +1,7 @@
 
 # dora
 
-![Version: 1.0.8](https://img.shields.io/badge/Version-1.0.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Beaconchain explorer is a tool that allows users to view and interact with the data on the Ethereum Beacon Chain. It is similar to a blockchain explorer, which allows users to view data on a blockchain such as the current state of transactions and blocks - but focussed on exploring the beaconchain.
 
@@ -99,7 +99,7 @@ A Beaconchain explorer is a tool that allows users to view and interact with the
 | proxyCount | int | `1` | Number of proxy servers in front of the explorer |
 | publicRpcUrl | string | `""` | Public RPC URL to use for the explorer |
 | rainbowkitProjectId | string | `""` | Rainbowkit project ID to use for the explorer |
-| ranges | list | `[]` |  |
+| ranges | object | `{}` |  |
 | readinessProbe | object | See `values.yaml` | Readiness probe |
 | replicas | int | `1` | Number of replicas |
 | resources | object | `{}` | Resource requests and limits |

--- a/charts/dora/values.yaml
+++ b/charts/dora/values.yaml
@@ -386,7 +386,7 @@ config: |
       {{- end }}
     {{- end }}
 
-ranges: []
+ranges: {}
 # 0-1: test
 
 # - HTTP port for dora interface


### PR DESCRIPTION
## Summary

- dora's validator names loader (`services/validatornames.go`) unmarshals `ranges.yaml` into `map[string]string`.
- #460 changed the default from a string template (`"0-1: test\n"`) to an empty list, and the configmap template now `toYaml`s it. With the default value `[]`, the rendered `ranges.yaml` is `[]` — a YAML sequence, not a map — which dora then rejects:

  ```
  level=error msg="error while loading validator names from yaml"
    error="error decoding validator names file /data/ranges.yaml:
      yaml: unmarshal errors:
        line 1: cannot unmarshal !!seq into map[string]string"
    module=validator_names
  ```

  Observed on glamsterdam-devnet-5 with the stock chart values.

- Switching the default to `{}` makes the rendered file an empty YAML map, which dora parses cleanly. `toYaml` of `{}` is still `{}`, so there's no change for users that override `ranges` with their own map (e.g. `ranges: {"0-1": test}`).

- Bumps chart version `1.0.8` → `1.0.9`; README regenerated via `make docs` (now shows `ranges | object | {}`).

## Test plan

- [x] `make docs` — README regenerated with no manual edits
- [x] `make lint` — `dora => (version: "1.0.9", path: "charts/dora")` lints clean
- [ ] Deploy with default values and confirm `module=validator_names` no longer logs the unmarshal error
- [ ] Deploy with a non-empty `ranges` map override and confirm names load (`loaded N validator names from yaml`)