### PR TITLE
dora: 1.0.10 — buildoor inventory config

### DIFF
--- a/charts/dora/Chart.yaml
+++ b/charts/dora/Chart.yaml
@@ -3,7 +3,7 @@ name: dora
 description: A Beaconchain explorer is a tool that allows users to view and interact with the data on the Ethereum Beacon Chain. It is similar to a blockchain explorer, which allows users to view data on a blockchain such as the current state of transactions and blocks - but focussed on exploring the beaconchain.
 home: https://github.com/pk910/dora
 type: application
-version: 1.0.9
+version: 1.0.10
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/dora/README.md
+++ b/charts/dora/README.md
@@ -1,7 +1,7 @@
 
 # dora
 
-![Version: 1.0.9](https://img.shields.io/badge/Version-1.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.0.10](https://img.shields.io/badge/Version-1.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Beaconchain explorer is a tool that allows users to view and interact with the data on the Ethereum Beacon Chain. It is similar to a blockchain explorer, which allows users to view data on a blockchain such as the current state of transactions and blocks - but focussed on exploring the beaconchain.
 
@@ -30,6 +30,8 @@ A Beaconchain explorer is a tool that allows users to view and interact with the
 | blockDbConfig | object | `{}` | Block database configuration |
 | blockDbEngine | string | `""` | Block database engine, available options `s3` or `pebble` |
 | blockDbNoBlocks | bool | `false` | Do not store full block bodies in the block database (only other metadata) |
+| buildoorOverviewUrl | string | `""` | Buildoor (https://github.com/ethpandaops/buildoor) overview server URL. -- When set, dora resolves builder names + external links via -- /api/overview/hosts + each instance's /api/buildoor/overview. |
+| buildoorUrls | list | `[]` | Explicit list of per-instance buildoor URLs. Takes precedence over -- buildoorOverviewUrl when populated. Each entry is polled at -- /api/buildoor/overview directly. |
 | callRateBurst | int | `10` | Page call burst limit per user |
 | callRateLimit | int | `2` | Page call limit per second per user |
 | config | string | See `values.yaml` | Config file |

--- a/charts/dora/values.yaml
+++ b/charts/dora/values.yaml
@@ -76,6 +76,16 @@ name: mainnet
 # -- If you want to use a local range file define it in the values.yaml ranges section
 validatorNamesInventory: ""
 
+# -- Buildoor (https://github.com/ethpandaops/buildoor) overview server URL.
+# -- When set, dora resolves builder names + external links via
+# -- /api/overview/hosts + each instance's /api/buildoor/overview.
+buildoorOverviewUrl: ""
+
+# -- Explicit list of per-instance buildoor URLs. Takes precedence over
+# -- buildoorOverviewUrl when populated. Each entry is polled at
+# -- /api/buildoor/overview directly.
+buildoorUrls: []
+
 # -- Link to the el block explorer
 ethExplorerLink: ""
 
@@ -212,6 +222,16 @@ config: |
       validatorNamesYaml: ""
       {{- end }}
       validatorNamesInventory: "{{ .Values.validatorNamesInventory }}"
+
+      # buildoor inventory for resolving builder names + external links
+      {{- if .Values.buildoorUrls }}
+      buildoorUrls:
+        {{- range .Values.buildoorUrls }}
+        - {{ . | quote }}
+        {{- end }}
+      {{- else if ne .Values.buildoorOverviewUrl "" }}
+      buildoorOverviewUrl: "{{ .Values.buildoorOverviewUrl }}"
+      {{- end }}
 
       # Show additional information in the UI
       showPeerDASInfos: true


### PR DESCRIPTION
## Summary

Adds two opt-in values for the buildoor inventory feature merged in https://github.com/ethpandaops/dora/pull/728:

- \`buildoorOverviewUrl\` — single multi-instance overview server URL
- \`buildoorUrls\` — explicit list of per-instance buildoor URLs (takes precedence when populated)

Default is empty for both, so existing deployments render unchanged. The values pair with each devnet's inventory variables in [ansible-collection-general#542](https://github.com/ethpandaops/ansible-collection-general/pull/542) (which now pins this chart at \`1.0.10\`).

## Chart bump

\`1.0.9\` → \`1.0.10\` (additive, backward-compatible).

## Test plan

- [x] \`make docs\` — README regenerated with the two new rows.
- [x] \`make lint\` — chart-testing + yamllint clean.
- [ ] Render with defaults → no \`buildoorUrls\` / \`buildoorOverviewUrl\` lines emitted.
- [ ] Render with \`buildoorOverviewUrl\` set → \`frontend.buildoorOverviewUrl\` appears in the dora config.
- [ ] Render with \`buildoorUrls: [...]\` set → \`frontend.buildoorUrls\` appears (overview is omitted).