### PR TITLE
feat(panda-chat): per-devnet AI chat chart (Open-WebUI + Hermes + panda)

### DIFF
--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -75,3 +75,4 @@ jobs:
           --excluded-charts cbt-api
           --excluded-charts observoor
           --excluded-charts xatu-consumoor
+          --excluded-charts panda-chat

--- a/charts/panda-chat/.helmignore
+++ b/charts/panda-chat/.helmignore
@@ -1,0 +1,8 @@
+# Patterns to ignore when building packages.
+*.tmpl
+.git/
+.gitignore
+*.tgz
+.vscode/
+.idea/
+README.md.gotmpl

--- a/charts/panda-chat/Chart.lock
+++ b/charts/panda-chat/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: open-webui
+  repository: https://helm.openwebui.com
+  version: 14.5.0
+digest: sha256:aa5b5a49cbbb030450d1578c6b87fe19faf724c19b1ddcb4d7af10b5c3be0f0d
+generated: "2026-06-02T16:50:10.322329968+02:00"

--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -1,0 +1,25 @@
+apiVersion: v2
+name: panda-chat
+description: AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
+home: https://github.com/ethpandaops/chat
+type: application
+version: 0.1.0
+# Hermes Agent upstream version baked into the panda-overlay image.
+appVersion: "0.11.0"
+keywords:
+  - llm
+  - agent
+  - hermes
+  - open-webui
+  - panda
+  - ethereum
+  - devnet
+maintainers:
+  - name: ethpandaops
+dependencies:
+  # Front end. Rendered under the `open-webui` values key. Talks to the
+  # in-chart Hermes agent over its OpenAI-compatible endpoint.
+  - name: open-webui
+    version: "14.5.0"
+    repository: "https://helm.openwebui.com"
+    condition: open-webui.enabled

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,0 +1,170 @@
+
+# panda-chat
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+
+AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
+
+**Homepage:** <https://github.com/ethpandaops/chat>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://helm.openwebui.com | open-webui | 14.5.0 |
+
+## What this deploys
+
+- **Open-WebUI** front end (subchart) on `chat.<network>` — the chat UI.
+- **Hermes agent** (NousResearch) as an OpenAI-compatible backend, wired to
+  the **`panda` CLI** for live devnet analytics (Xatu / Prometheus / Loki /
+  Dora / Ethnode via the hosted panda-proxy).
+- Agent **skills** for the EthPandaOps tools: `panda` (query), `faucet`
+  (fund accounts via the devnet powfaucet) and `join-devnet` (enodes /
+  bootnodes / genesis from the devnet `config` service).
+- Optional **Langfuse** tracing (`langfuse.enabled`) via Hermes' bundled
+  `observability/langfuse` plugin — one span per turn, one generation per LLM
+  call, one observation per tool call; traces tagged with the devnet name.
+
+When `panda.enabled` is true the agent pod runs `panda-server` + `dockerd`
+alongside Hermes and is **privileged** (dockerd needs root). The bot identity
+for the proxy is provisioned once (GitHub bot user + `panda auth login`) and
+its credentials are supplied via `credentials.panda.*`.
+
+## Access control
+
+The chart serves a **public** ingress by default (like Dora). Because the agent
+incurs real LLM spend, gate it to your org with **Cloudflare Access** — the same
+edge gate the devnet already runs (authenticatoor / faucet rely on it). CF Access
+verifies org membership and passes the identity to the origin as
+`Cf-Access-Authenticated-User-Email`; Open-WebUI consumes it as **trusted-header
+SSO** (no password), auto-provisioning the user on first visit.
+
+1. Create a Cloudflare Access application on `chat.<network>` scoped to the org
+   (e.g. the ethpandaops GitHub org). This is the only out-of-band step — the same
+   primitive that already gates `auth.<network>`.
+2. Enable trusted-header SSO:
+
+   ```yaml
+   open-webui:
+     sso:
+       enabled: true
+       enableSignup: true            # auto-provision on first login
+       trustedHeader:
+         enabled: true
+         emailHeader: Cf-Access-Authenticated-User-Email
+     extraEnvVars:
+       - name: ENABLE_LOGIN_FORM      # hide the password form
+         value: "false"
+   ```
+
+> ⚠️ Trust model: the chat host must only be reachable **via Cloudflare**, so the
+> email header can't be spoofed by hitting the origin directly — the same
+> assumption authenticatoor and the rest of the devnet stack already rely on.
+
+Per-user identity is also propagated to the agent: the Open-WebUI image
+(`ethpandaops/open-webui-cf`) forwards `Cf-Access-Jwt-Assertion` upstream so
+Hermes sees the individual user (per-user auth on downstream resources + Langfuse
+attribution). On devnets the bal-devnets ansible template wires the trusted-header
+config from a single toggle — see `chat.yaml.j2`.
+
+## Image
+
+Two images, both built from [`ethpandaops/chat`](https://github.com/ethpandaops/chat):
+
+- `image.repository` (`ethpandaops/hermes-agent-panda`) — the Hermes agent
+  with the panda overlay (panda CLI + panda-server + dockerd + entrypoint + skills).
+- `open-webui.image` (`ethpandaops/open-webui-cf`) — Open-WebUI patched to
+  forward the Cloudflare Access JWT to the agent (see [Access control](#access-control)).
+  Its tag must match the `open-webui` subchart appVersion.
+
+## Wiring the front end to the agent
+
+The chart does not assume the release name, so set the agent endpoint on the
+subchart (the bal-devnets ansible template does this automatically):
+
+```yaml
+open-webui:
+  openaiBaseApiUrls:
+    - "http://<release>-hermes:8642/v1"
+  extraEnvVars:
+    - name: OPENAI_API_KEYS
+      valueFrom:
+        secretKeyRef:
+          name: <release>-hermes-secret
+          key: API_SERVER_KEY
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity for the agent pod |
+| chainId | string | `""` | The devnet chain id (informational; surfaced to the join-devnet skill). |
+| credentials.langfuse.publicKey | string | `""` | Langfuse public key (pk-lf-...) |
+| credentials.langfuse.secretKey | string | `""` | Langfuse secret key (sk-lf-...) |
+| credentials.llmApiKey | string | `""` | The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`) |
+| credentials.panda.credentialsFile | string | `""` | Filename panda expects under credentials/ (derived from issuer+client hash) |
+| credentials.panda.credentialsJson | string | `""` | panda-server bot credentials JSON (contents of credentials/<hash>.json) |
+| devnetTools.faucet.enabled | bool | `true` | Enable the faucet (account funding) skill |
+| devnetTools.faucet.url | string | `""` | powfaucet base URL |
+| devnetTools.join.configUrl | string | `""` | Base config service URL (serves /cl/config.yaml, /el/enodes.txt, etc.) |
+| devnetTools.join.enabled | bool | `true` | Enable the join-devnet skill |
+| devnetTools.join.explorerUrl | string | `""` | Block explorer URL |
+| devnetTools.join.rpcUrl | string | `""` | Public execution RPC URL |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
+| image.repository | string | `"ethpandaops/hermes-agent-panda"` | Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server + dockerd). |
+| image.tag | string | `""` | Image tag. Defaults to the chart appVersion when empty. |
+| imagePullSecrets | list | `[]` | Image pull secrets for the agent image |
+| langfuse.baseUrl | string | `""` | Langfuse base URL |
+| langfuse.enabled | bool | `false` | Enable Langfuse tracing |
+| langfuse.env | string | `""` | Environment tag on traces (defaults to `network` when empty) |
+| llm.apiKeyEnv | string | `"ANTHROPIC_API_KEY"` | Env var the agent reads the model key from (must match a key materialized by `credentials`) |
+| llm.apiMode | string | `""` | Hermes api_mode (chat_completions / anthropic_messages / ...); auto-detected from URL when empty |
+| llm.baseUrl | string | `""` | Base URL override (required for `custom`; optional override otherwise) |
+| llm.model | string | `"claude-sonnet-4-6"` | Model identifier |
+| llm.provider | string | `"anthropic"` | Hermes provider name (anthropic / openai / custom / minimax / ...) |
+| nameOverride | string | `""` | Overrides the chart's name |
+| network | string | `""` | The devnet network this chat serves (e.g. `bal-devnet-7`). Used to scope panda queries and surfaced to the agent so it answers in-context. |
+| nodeSelector | object | `{}` | Node selector for the agent pod |
+| open-webui.enabled | bool | `true` | Render the Open-WebUI front end |
+| open-webui.extraEnvVars[0].name | string | `"ENABLE_OLLAMA_API"` |  |
+| open-webui.extraEnvVars[0].value | string | `"false"` |  |
+| open-webui.image.repository | string | `"ethpandaops/open-webui-cf"` |  |
+| open-webui.image.tag | string | `"0.9.5"` |  |
+| open-webui.ingress.annotations | object | `{}` |  |
+| open-webui.ingress.class | string | `"ingress-nginx-public"` |  |
+| open-webui.ingress.enabled | bool | `true` |  |
+| open-webui.ingress.host | string | `""` |  |
+| open-webui.ollama.enabled | bool | `false` |  |
+| open-webui.persistence.enabled | bool | `true` |  |
+| open-webui.persistence.size | string | `"5Gi"` |  |
+| open-webui.pipelines.enabled | bool | `false` |  |
+| open-webui.replicaCount | int | `1` |  |
+| open-webui.sso.enableSignup | bool | `true` |  |
+| open-webui.sso.enabled | bool | `false` |  |
+| open-webui.sso.trustedHeader.emailHeader | string | `"Cf-Access-Authenticated-User-Email"` |  |
+| open-webui.sso.trustedHeader.enabled | bool | `false` |  |
+| open-webui.sso.trustedHeader.nameHeader | string | `""` |  |
+| open-webui.websocket.enabled | bool | `false` |  |
+| open-webui.websocket.redis.enabled | bool | `false` |  |
+| panda.clientId | string | `"panda-proxy"` | OIDC client id at the proxy |
+| panda.enabled | bool | `true` | Enable the panda sidecar processes + privileged pod |
+| panda.issuerUrl | string | `"https://dex.primary.production.platform.ethpandaops.io"` | OIDC issuer (Dex) the bot identity authenticates against |
+| panda.proxyUrl | string | `"https://panda-proxy.analytics.production.platform.ethpandaops.io"` | Hosted panda-proxy URL (analytics data plane) |
+| panda.sandboxImage | string | `"ethpandaops/panda:sandbox-v0.31.0"` | Sandbox container image panda-server spawns for Python execution |
+| panda.storageDriver | string | `"overlay2"` | dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod) |
+| persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes |
+| persistence.enabled | bool | `true` | Enable a PVC for /opt/data (Hermes state + panda config/creds/storage) |
+| persistence.existingClaim | string | `""` | Use an existing claim instead of creating one |
+| persistence.size | string | `"8Gi"` | PVC size |
+| persistence.storageClass | string | `""` | Storage class (cluster default when empty) |
+| resources | object | `{"limits":{"cpu":"3000m","memory":"6Gi"},"requests":{"cpu":"300m","memory":"1Gi"}}` | Resources for the agent pod (Hermes + panda-server + dockerd + sandboxes) |
+| service.port | int | `8642` | Agent service port (Hermes OpenAI-compatible API) |
+| service.type | string | `"ClusterIP"` | Agent service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Create a service account for the agent |
+| serviceAccount.name | string | `""` | Service account name (defaults to the fullname) |
+| systemPrompt | string | `"You are the EthPandaOps assistant for the Ethereum devnet \"{{ network }}\".\nHelp users understand devnet state and use the EthPandaOps tooling:\nquery live data with the `panda` skill, fund accounts with the `faucet`\nskill, and join the network with the `join-devnet` skill. Be concise and\nalways scope data queries to this devnet.\n"` | System prompt for the agent. `{{ network }}` is substituted at render time. |
+| tolerations | list | `[]` | Tolerations for the agent pod |

--- a/charts/panda-chat/README.md.gotmpl
+++ b/charts/panda-chat/README.md.gotmpl
@@ -1,0 +1,95 @@
+
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## What this deploys
+
+- **Open-WebUI** front end (subchart) on `chat.<network>` — the chat UI.
+- **Hermes agent** (NousResearch) as an OpenAI-compatible backend, wired to
+  the **`panda` CLI** for live devnet analytics (Xatu / Prometheus / Loki /
+  Dora / Ethnode via the hosted panda-proxy).
+- Agent **skills** for the EthPandaOps tools: `panda` (query), `faucet`
+  (fund accounts via the devnet powfaucet) and `join-devnet` (enodes /
+  bootnodes / genesis from the devnet `config` service).
+- Optional **Langfuse** tracing (`langfuse.enabled`) via Hermes' bundled
+  `observability/langfuse` plugin — one span per turn, one generation per LLM
+  call, one observation per tool call; traces tagged with the devnet name.
+
+When `panda.enabled` is true the agent pod runs `panda-server` + `dockerd`
+alongside Hermes and is **privileged** (dockerd needs root). The bot identity
+for the proxy is provisioned once (GitHub bot user + `panda auth login`) and
+its credentials are supplied via `credentials.panda.*`.
+
+## Access control
+
+The chart serves a **public** ingress by default (like Dora). Because the agent
+incurs real LLM spend, gate it to your org with **Cloudflare Access** — the same
+edge gate the devnet already runs (authenticatoor / faucet rely on it). CF Access
+verifies org membership and passes the identity to the origin as
+`Cf-Access-Authenticated-User-Email`; Open-WebUI consumes it as **trusted-header
+SSO** (no password), auto-provisioning the user on first visit.
+
+1. Create a Cloudflare Access application on `chat.<network>` scoped to the org
+   (e.g. the ethpandaops GitHub org). This is the only out-of-band step — the same
+   primitive that already gates `auth.<network>`.
+2. Enable trusted-header SSO:
+
+   ```yaml
+   open-webui:
+     sso:
+       enabled: true
+       enableSignup: true            # auto-provision on first login
+       trustedHeader:
+         enabled: true
+         emailHeader: Cf-Access-Authenticated-User-Email
+     extraEnvVars:
+       - name: ENABLE_LOGIN_FORM      # hide the password form
+         value: "false"
+   ```
+
+> ⚠️ Trust model: the chat host must only be reachable **via Cloudflare**, so the
+> email header can't be spoofed by hitting the origin directly — the same
+> assumption authenticatoor and the rest of the devnet stack already rely on.
+
+Per-user identity is also propagated to the agent: the Open-WebUI image
+(`ethpandaops/open-webui-cf`) forwards `Cf-Access-Jwt-Assertion` upstream so
+Hermes sees the individual user (per-user auth on downstream resources + Langfuse
+attribution). On devnets the bal-devnets ansible template wires the trusted-header
+config from a single toggle — see `chat.yaml.j2`.
+
+## Image
+
+Two images, both built from [`ethpandaops/chat`](https://github.com/ethpandaops/chat):
+
+- `image.repository` (`ethpandaops/hermes-agent-panda`) — the Hermes agent
+  with the panda overlay (panda CLI + panda-server + dockerd + entrypoint + skills).
+- `open-webui.image` (`ethpandaops/open-webui-cf`) — Open-WebUI patched to
+  forward the Cloudflare Access JWT to the agent (see [Access control](#access-control)).
+  Its tag must match the `open-webui` subchart appVersion.
+
+## Wiring the front end to the agent
+
+The chart does not assume the release name, so set the agent endpoint on the
+subchart (the bal-devnets ansible template does this automatically):
+
+```yaml
+open-webui:
+  openaiBaseApiUrls:
+    - "http://<release>-hermes:8642/v1"
+  extraEnvVars:
+    - name: OPENAI_API_KEYS
+      valueFrom:
+        secretKeyRef:
+          name: <release>-hermes-secret
+          key: API_SERVER_KEY
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/panda-chat/templates/NOTES.txt
+++ b/charts/panda-chat/templates/NOTES.txt
@@ -1,0 +1,30 @@
+panda-chat deployed for network "{{ .Values.network | default "(unset)" }}".
+
+Front end (Open-WebUI):
+{{- if (index .Values "open-webui").ingress.enabled }}
+  https://{{ (index .Values "open-webui").ingress.host | default "(set open-webui.ingress.host)" }}
+{{- else }}
+  open-webui.ingress.enabled is false — port-forward the open-webui service to reach the UI.
+{{- end }}
+
+Hermes agent (OpenAI-compatible, in-cluster only):
+  http://{{ include "panda-chat.hermesFullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/v1
+
+IMPORTANT — wire the front end to the agent (the chart does not assume the
+release name). Set these on the open-webui subchart:
+
+  open-webui:
+    openaiBaseApiUrls:
+      - "http://{{ include "panda-chat.hermesFullname" . }}:{{ .Values.service.port }}/v1"
+    extraEnvVars:
+      - name: OPENAI_API_KEYS
+        valueFrom:
+          secretKeyRef:
+            name: {{ include "panda-chat.secretName" . }}
+            key: API_SERVER_KEY
+
+{{- if .Values.panda.enabled }}
+
+Panda is ENABLED — the agent pod is privileged and runs dockerd + panda-server.
+Provision the bot identity and fill credentials.panda.* (see the chart README).
+{{- end }}

--- a/charts/panda-chat/templates/_helpers.tpl
+++ b/charts/panda-chat/templates/_helpers.tpl
@@ -1,0 +1,85 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "panda-chat.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "panda-chat.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+The Hermes agent resources (deployment/service/secret/configmap/pvc) all
+hang off this name so the front end can target a deterministic service.
+*/}}
+{{- define "panda-chat.hermesFullname" -}}
+{{- printf "%s-hermes" (include "panda-chat.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "panda-chat.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "panda-chat.labels" -}}
+helm.sh/chart: {{ include "panda-chat.chart" . }}
+{{ include "panda-chat.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: agent
+{{- end }}
+
+{{- define "panda-chat.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "panda-chat.hermesFullname" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "panda-chat.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "panda-chat.hermesFullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Agent image reference. Tag defaults to the chart appVersion.
+*/}}
+{{- define "panda-chat.image" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{ .Values.image.repository }}:{{ $tag }}
+{{- end }}
+
+{{/*
+Secret holding the Hermes bearer (API_SERVER_KEY), the LLM model key and
+the panda bot credentials.
+*/}}
+{{- define "panda-chat.secretName" -}}
+{{- printf "%s-secret" (include "panda-chat.hermesFullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "panda-chat.configMapName" -}}
+{{- printf "%s-config" (include "panda-chat.hermesFullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "panda-chat.pvcName" -}}
+{{- if .Values.persistence.existingClaim -}}
+{{ .Values.persistence.existingClaim }}
+{{- else -}}
+{{ include "panda-chat.hermesFullname" . }}-data
+{{- end }}
+{{- end }}

--- a/charts/panda-chat/templates/configmap.yaml
+++ b/charts/panda-chat/templates/configmap.yaml
@@ -1,0 +1,52 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "panda-chat.configMapName" . }}
+  labels: {{- include "panda-chat.labels" . | nindent 4 }}
+data:
+  # Hermes config — seeded into /opt/data/config.yaml.
+  config.yaml: |
+    model:
+      default: {{ .Values.llm.model | quote }}
+      provider: {{ .Values.llm.provider | quote }}
+      api_key_env: {{ .Values.llm.apiKeyEnv | quote }}
+      {{- with .Values.llm.baseUrl }}
+      base_url: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.llm.apiMode }}
+      api_mode: {{ . | quote }}
+      {{- end }}
+    agent:
+      system_prompt: |
+        {{- .Values.systemPrompt | replace "{{ network }}" .Values.network | nindent 8 }}
+    honcho:
+      enabled: true
+    {{- if .Values.langfuse.enabled }}
+    plugins:
+      enabled:
+        - observability/langfuse
+    {{- end }}
+  {{- if .Values.panda.enabled }}
+  # panda-server config — seeded to /opt/data/.config/panda/config.yaml (creds live in the Secret).
+  panda-config.yaml: |
+    server:
+      host: "127.0.0.1"
+      port: 2480
+      base_url: "http://127.0.0.1:2480"
+      sandbox_url: "http://172.17.0.1:2480"
+    sandbox:
+      backend: docker
+      image: {{ .Values.panda.sandboxImage | quote }}
+      network: "bridge"
+      timeout: 300
+      memory_limit: "1g"
+      cpu_limit: 1.0
+    storage:
+      base_dir: "/opt/data/panda-storage"
+    proxy:
+      url: {{ .Values.panda.proxyUrl | quote }}
+      auth:
+        mode: "oidc"
+        issuer_url: {{ .Values.panda.issuerUrl | quote }}
+        client_id: {{ .Values.panda.clientId | quote }}
+  {{- end }}

--- a/charts/panda-chat/templates/deployment.yaml
+++ b/charts/panda-chat/templates/deployment.yaml
@@ -1,0 +1,194 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "panda-chat.hermesFullname" . }}
+  labels: {{- include "panda-chat.labels" . | nindent 4 }}
+spec:
+  # Single replica: Hermes holds SQLite state on an RWO PVC.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels: {{- include "panda-chat.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels: {{- include "panda-chat.labels" . | nindent 8 }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ include "panda-chat.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.panda.enabled }}
+      # panda: dockerd needs root, so only fsGroup applies (lets the init containers write the PVC).
+      securityContext:
+        fsGroup: 10000
+      {{- else }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 10000
+        runAsGroup: 10000
+        fsGroup: 10000
+      {{- end }}
+      initContainers:
+        # Seed Hermes (and panda) config onto the PVC.
+        - name: seed-config
+          image: busybox:1.37
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -eu
+              mkdir -p /data
+              new=$(sha256sum /config-src/config.yaml | cut -d' ' -f1)
+              old=""
+              [ -f /data/config.yaml ] && old=$(sha256sum /data/config.yaml | cut -d' ' -f1)
+              [ "$new" != "$old" ] && cp /config-src/config.yaml /data/config.yaml || true
+              {{- if .Values.panda.enabled }}
+              mkdir -p /data/.config/panda/credentials /data/panda-storage
+              cp /config-src/panda-config.yaml /data/.config/panda/config.yaml
+              {{- end }}
+          volumeMounts:
+            - {name: config, mountPath: /config-src}
+            - {name: data, mountPath: /data}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+        {{- if .Values.panda.enabled }}
+        # Seed panda bot credentials from the Secret (refreshed every pod start).
+        - name: seed-panda-creds
+          image: busybox:1.37
+          command: ["sh", "-c"]
+          args:
+            - |
+              set -eu
+              mkdir -p /data/.config/panda/credentials
+              if [ -n "${PANDA_CREDENTIALS_JSON:-}" ] && [ -n "${PANDA_CREDENTIALS_FILE:-}" ]; then
+                printf '%s' "$PANDA_CREDENTIALS_JSON" \
+                  > "/data/.config/panda/credentials/${PANDA_CREDENTIALS_FILE}"
+              fi
+          envFrom:
+            - secretRef:
+                name: {{ include "panda-chat.secretName" . }}
+                optional: true
+          volumeMounts:
+            - {name: data, mountPath: /data}
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
+        {{- end }}
+      containers:
+        - name: hermes
+          image: {{ include "panda-chat.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.panda.enabled }}
+          # privileged for dockerd; the image ENTRYPOINT starts dockerd + panda-server before Hermes.
+          securityContext:
+            privileged: true
+          {{- else }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            capabilities:
+              drop: [ALL]
+          command: ["/opt/hermes/docker/entrypoint.sh"]
+          args: ["gateway", "run"]
+          {{- end }}
+          env:
+            - {name: API_SERVER_HOST, value: "0.0.0.0"}
+            - {name: API_SERVER_PORT, value: "8642"}
+            - {name: API_SERVER_MODEL_NAME, value: "hermes-agent"}
+            - name: API_SERVER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "panda-chat.secretName" . }}
+                  key: API_SERVER_KEY
+            - {name: HERMES_DATA_DIR, value: "/opt/data"}
+            - {name: HERMES_UID, value: "10000"}
+            - {name: HERMES_GID, value: "10000"}
+            {{- if .Values.panda.enabled }}
+            - {name: DOCKERD_STORAGE_DRIVER, value: {{ .Values.panda.storageDriver | quote }}}
+            - {name: PANDA_SERVER_URL, value: "http://127.0.0.1:2480"}
+            {{- end }}
+            # Devnet context for the agent + skills.
+            - {name: DEVNET_NETWORK, value: {{ .Values.network | quote }}}
+            - {name: DEVNET_CHAIN_ID, value: {{ .Values.chainId | quote }}}
+            {{- if .Values.devnetTools.faucet.enabled }}
+            - {name: DEVNET_FAUCET_URL, value: {{ .Values.devnetTools.faucet.url | quote }}}
+            {{- end }}
+            {{- if .Values.devnetTools.join.enabled }}
+            - {name: DEVNET_CONFIG_URL, value: {{ .Values.devnetTools.join.configUrl | quote }}}
+            - {name: DEVNET_RPC_URL, value: {{ .Values.devnetTools.join.rpcUrl | quote }}}
+            - {name: DEVNET_EXPLORER_URL, value: {{ .Values.devnetTools.join.explorerUrl | quote }}}
+            {{- end }}
+            {{- if .Values.langfuse.enabled }}
+            # Langfuse keys come via envFrom (Secret); URL + env tag are plain.
+            - {name: HERMES_LANGFUSE_BASE_URL, value: {{ .Values.langfuse.baseUrl | quote }}}
+            - {name: HERMES_LANGFUSE_ENV, value: {{ .Values.langfuse.env | default .Values.network | quote }}}
+            {{- end }}
+          envFrom:
+            - secretRef:
+                name: {{ include "panda-chat.secretName" . }}
+                optional: true
+          ports:
+            - {name: http, containerPort: 8642, protocol: TCP}
+          {{- if .Values.panda.enabled }}
+          # ~5 min budget: dockerd + sandbox image pull + panda-server + hermes.
+          startupProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - curl -sf http://127.0.0.1:2480/health && curl -sf http://127.0.0.1:8642/health
+            periodSeconds: 5
+            failureThreshold: 60
+          readinessProbe:
+            httpGet: {path: /health, port: http}
+            initialDelaySeconds: 60
+            periodSeconds: 5
+          livenessProbe:
+            httpGet: {path: /health, port: http}
+            initialDelaySeconds: 120
+            periodSeconds: 30
+          {{- else }}
+          readinessProbe:
+            httpGet: {path: /health, port: http}
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          livenessProbe:
+            httpGet: {path: /health, port: http}
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          {{- end }}
+          resources: {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - {name: data, mountPath: /opt/data}
+            - {name: config, mountPath: /config-src, readOnly: true}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "panda-chat.configMapName" . }}
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "panda-chat.pvcName" . }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/panda-chat/templates/pvc.yaml
+++ b/charts/panda-chat/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "panda-chat.pvcName" . }}
+  labels: {{- include "panda-chat.labels" . | nindent 4 }}
+spec:
+  accessModes: {{- toYaml .Values.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/panda-chat/templates/secret.yaml
+++ b/charts/panda-chat/templates/secret.yaml
@@ -1,0 +1,41 @@
+{{/*
+Holds: API_SERVER_KEY (Hermes bearer, generated once and preserved),
+<llm.apiKeyEnv> (model key), PANDA_CREDENTIALS_* (panda bot creds)
+and HERMES_LANGFUSE_* (tracing keys).
+*/}}
+{{- $secretName := include "panda-chat.secretName" . -}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $bearer := "" -}}
+{{- if and $existing $existing.data -}}
+  {{- with index $existing.data "API_SERVER_KEY" -}}
+    {{- $bearer = . | b64dec -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $bearer -}}{{- $bearer = randAlphaNum 40 -}}{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  labels: {{- include "panda-chat.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  API_SERVER_KEY: {{ $bearer | quote }}
+  {{- with .Values.credentials.llmApiKey }}
+  {{ $.Values.llm.apiKeyEnv }}: {{ . | quote }}
+  {{- end }}
+  {{- if .Values.panda.enabled }}
+  {{- with .Values.credentials.panda.credentialsJson }}
+  PANDA_CREDENTIALS_JSON: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.credentials.panda.credentialsFile }}
+  PANDA_CREDENTIALS_FILE: {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if .Values.langfuse.enabled }}
+  {{- with .Values.credentials.langfuse.publicKey }}
+  HERMES_LANGFUSE_PUBLIC_KEY: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.credentials.langfuse.secretKey }}
+  HERMES_LANGFUSE_SECRET_KEY: {{ . | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/panda-chat/templates/service.yaml
+++ b/charts/panda-chat/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "panda-chat.hermesFullname" . }}
+  labels: {{- include "panda-chat.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector: {{- include "panda-chat.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/panda-chat/templates/serviceaccount.yaml
+++ b/charts/panda-chat/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "panda-chat.serviceAccountName" . }}
+  labels: {{- include "panda-chat.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -1,0 +1,194 @@
+# -- Overrides the chart's name
+nameOverride: ""
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+# -- The devnet network this chat serves (e.g. `bal-devnet-7`). Used to
+# scope panda queries and surfaced to the agent so it answers in-context.
+network: ""
+
+# -- The devnet chain id (informational; surfaced to the join-devnet skill).
+chainId: ""
+
+image:
+  # -- Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server + dockerd).
+  repository: ethpandaops/hermes-agent-panda
+  # -- Image tag. Defaults to the chart appVersion when empty.
+  tag: ""
+  # -- Image pull policy
+  pullPolicy: IfNotPresent
+
+# -- Image pull secrets for the agent image
+imagePullSecrets: []
+
+# LLM provider. The key comes from the Secret (credentials.llmApiKey) into the env var named by apiKeyEnv.
+llm:
+  # -- Hermes provider name (anthropic / openai / custom / minimax / ...)
+  provider: anthropic
+  # -- Model identifier
+  model: claude-sonnet-4-6
+  # -- Base URL override (required for `custom`; optional override otherwise)
+  baseUrl: ""
+  # -- Hermes api_mode (chat_completions / anthropic_messages / ...); auto-detected from URL when empty
+  apiMode: ""
+  # -- Env var the agent reads the model key from (must match a key materialized by `credentials`)
+  apiKeyEnv: ANTHROPIC_API_KEY
+
+# -- System prompt for the agent. `{{ network }}` is substituted at render time.
+systemPrompt: |
+  You are the EthPandaOps assistant for the Ethereum devnet "{{ network }}".
+  Help users understand devnet state and use the EthPandaOps tooling:
+  query live data with the `panda` skill, fund accounts with the `faucet`
+  skill, and join the network with the `join-devnet` skill. Be concise and
+  always scope data queries to this devnet.
+
+# Panda integration. When enabled the agent pod runs panda-server + dockerd and is privileged.
+panda:
+  # -- Enable the panda sidecar processes + privileged pod
+  enabled: true
+  # -- Hosted panda-proxy URL (analytics data plane)
+  proxyUrl: "https://panda-proxy.analytics.production.platform.ethpandaops.io"
+  # -- OIDC issuer (Dex) the bot identity authenticates against
+  issuerUrl: "https://dex.primary.production.platform.ethpandaops.io"
+  # -- OIDC client id at the proxy
+  clientId: "panda-proxy"
+  # -- Sandbox container image panda-server spawns for Python execution
+  sandboxImage: "ethpandaops/panda:sandbox-v0.31.0"
+  # -- dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod)
+  storageDriver: overlay2
+
+# LLM-call tracing via Hermes' bundled observability/langfuse plugin.
+# Keys come from credentials.langfuse; fail-open if absent.
+langfuse:
+  # -- Enable Langfuse tracing
+  enabled: false
+  # -- Langfuse base URL
+  baseUrl: ""
+  # -- Environment tag on traces (defaults to `network` when empty)
+  env: ""
+
+# Devnet tooling endpoints exposed to the agent skills (filled per-devnet by the ansible template).
+devnetTools:
+  faucet:
+    # -- Enable the faucet (account funding) skill
+    enabled: true
+    # -- powfaucet base URL
+    url: ""
+  join:
+    # -- Enable the join-devnet skill
+    enabled: true
+    # -- Base config service URL (serves /cl/config.yaml, /el/enodes.txt, etc.)
+    configUrl: ""
+    # -- Public execution RPC URL
+    rpcUrl: ""
+    # -- Block explorer URL
+    explorerUrl: ""
+
+# Credentials. Injected via vals `<path:...>` on devnets; set directly for standalone use.
+credentials:
+  # -- The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`)
+  llmApiKey: ""
+  panda:
+    # -- panda-server bot credentials JSON (contents of credentials/<hash>.json)
+    credentialsJson: ""
+    # -- Filename panda expects under credentials/ (derived from issuer+client hash)
+    credentialsFile: ""
+  langfuse:
+    # -- Langfuse public key (pk-lf-...)
+    publicKey: ""
+    # -- Langfuse secret key (sk-lf-...)
+    secretKey: ""
+
+# -- Resources for the agent pod (Hermes + panda-server + dockerd + sandboxes)
+resources:
+  requests:
+    cpu: 300m
+    memory: 1Gi
+  limits:
+    cpu: 3000m
+    memory: 6Gi
+
+persistence:
+  # -- Enable a PVC for /opt/data (Hermes state + panda config/creds/storage)
+  enabled: true
+  # -- PVC size
+  size: 8Gi
+  # -- Storage class (cluster default when empty)
+  storageClass: ""
+  # -- Access modes
+  accessModes:
+    - ReadWriteOnce
+  # -- Use an existing claim instead of creating one
+  existingClaim: ""
+
+serviceAccount:
+  # -- Create a service account for the agent
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- Service account name (defaults to the fullname)
+  name: ""
+
+service:
+  # -- Agent service type
+  type: ClusterIP
+  # -- Agent service port (Hermes OpenAI-compatible API)
+  port: 8642
+
+# -- Node selector for the agent pod
+nodeSelector: {}
+# -- Tolerations for the agent pod
+tolerations: []
+# -- Affinity for the agent pod
+affinity: {}
+
+# Open-WebUI front end (subchart). The ansible template adds the ingress host,
+# panda-menu annotations, and the agent endpoint wiring (openaiBaseApiUrls + OPENAI_API_KEYS).
+open-webui:
+  # -- Render the Open-WebUI front end
+  enabled: true
+  replicaCount: 1
+  # CF-Access-aware Open-WebUI: forwards Cf-Access-Jwt-Assertion to the agent so
+  # Hermes sees the individual user (per-user auth + Langfuse attribution). The tag
+  # MUST match this subchart's appVersion (open-webui 14.5.0 -> 0.9.5); bump together.
+  # Built from github.com/ethpandaops/chat (images/open-webui-cf).
+  image:
+    repository: ethpandaops/open-webui-cf
+    tag: "0.9.5"
+  # Route models through Hermes, not the bundled Ollama / Pipelines.
+  ollama:
+    enabled: false
+  pipelines:
+    enabled: false
+  websocket:
+    enabled: false
+    redis:
+      enabled: false
+  persistence:
+    enabled: true
+    size: 5Gi
+  # Access control. Gate the UI at the Cloudflare Access edge (org-scoped) —
+  # the devnet's existing auth gate (authenticatoor/faucet rely on it). CF Access
+  # passes the verified identity as `Cf-Access-Authenticated-User-Email`, which
+  # Open-WebUI consumes as trusted-header SSO (no password). Off by default
+  # (public, like Dora); the bal-devnets template flips it on per devnet.
+  # Requires one Cloudflare Access application on chat.<network> scoped to the org.
+  sso:
+    enabled: false
+    # Auto-provision a Open-WebUI account on first trusted-header login.
+    enableSignup: true
+    trustedHeader:
+      enabled: false
+      # Header Cloudflare Access sets with the authenticated user's email.
+      emailHeader: Cf-Access-Authenticated-User-Email
+      nameHeader: ""
+  ingress:
+    enabled: true
+    class: ingress-nginx-public
+    # host + annotations filled by the ansible template / per-devnet values
+    host: ""
+    annotations: {}
+  extraEnvVars:
+    - name: ENABLE_OLLAMA_API
+      value: "false"

--- a/ct.yaml
+++ b/ct.yaml
@@ -14,3 +14,4 @@ chart-repos:
   - ethereum-helm-charts=https://ethpandaops.github.io/ethereum-helm-charts
   - bjw-s=https://bjw-s-labs.github.io/helm-charts
   - chaos-mesh=https://charts.chaos-mesh.org
+  - open-webui=https://helm.openwebui.com


### PR DESCRIPTION
## What

New umbrella chart **`panda-chat`** — an AI chat endpoint for a devnet, the same way a devnet gets Dora. Open-WebUI front end → NousResearch Hermes agent → `panda` CLI (devnet analytics via the hosted panda-proxy), plus `faucet` (fund accounts) and `join-devnet` skills.

- Open-WebUI as a dependency subchart (`open-webui` 14.5.0), single ingress `chat.<network>`.
- Hermes agent as an OpenAI-compatible backend; image `ethpandaops/hermes-agent-panda`.
- When `panda.enabled` (default), the agent pod runs `panda-server` + `dockerd` and is **privileged** (dockerd needs root); `seed-config` + `seed-panda-creds` init containers.
- Optional **Langfuse** tracing via Hermes' bundled `observability/langfuse` plugin (`langfuse.enabled`).
- `ct.yaml`: adds the `open-webui` helm repo so chart-testing can resolve the dep.

## Review order — this is step 1 of 4

This chart **must publish to the index first** — the `ansible-collection-general` change resolves `panda-chat 0.1.0` from `https://ethpandaops.github.io/ethereum-helm-charts`. Nothing downstream renders until this is merged + published.

1. **(this PR)** ethereum-helm-charts — publish the chart
2. ansible-collection-general — register the `chat` service (pulls this chart)
3. secrets: add `chat` section to `services.enc.yaml` + provision panda bot identity
4. bal-devnets — enable on devnet-7, render `kubernetes/devnet-7/chat/`, ArgoCD deploys

## Notes for reviewers

- The chart is release-name-agnostic; the bal-devnets ansible template wires the Open-WebUI→Hermes endpoint (`openaiBaseApiUrls` + `OPENAI_API_KEYS` from the chart secret).
- ⚠️ Before deploy: the agent image's **base** (`hermes-agent-base`) is lab-built today (`git.starflinger.eu`) — promote it (and the overlay) to `ghcr.io/ethpandaops`, or set an `imagePullSecret`. Tracked for step 4, not blocking the chart publish.
- `helm lint` passes; `*.tgz` is gitignored so the commit carries only `Chart.lock` + sources.

Source of the agent image + skills: the `chat` lab repo (`images/hermes-agent-panda/`).