### PR TITLE
ci(release): add open-webui helm repo so panda-chat packages

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,6 +32,7 @@ jobs:
           helm repo add ethpandaops https://ethpandaops.github.io/ethereum-helm-charts
           helm repo add bjw-s https://bjw-s-labs.github.io/helm-charts
           helm repo add chaos-mesh https://charts.chaos-mesh.org
+          helm repo add open-webui https://helm.openwebui.com
           
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0


### PR DESCRIPTION
The `release` workflow's chart-releaser fails packaging **panda-chat** with `Error: no repository definition for https://helm.openwebui.com` — the open-webui dependency repo is registered in `ct.yaml`/test-charts but was missing from `release.yaml`'s "Add repo dependencies" step. This one-line add unblocks publishing panda-chat (and any future open-webui-based chart) to the index.

Follow-up to #476 (merged). Until this lands + the release re-runs, `panda-chat 0.1.0` won't appear in the chart index.