### PR TITLE
ci(release): build chart deps before chart-releaser so panda-chat publishes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,20 @@ jobs:
           helm repo add bjw-s https://bjw-s-labs.github.io/helm-charts
           helm repo add chaos-mesh https://charts.chaos-mesh.org
           helm repo add open-webui https://helm.openwebui.com
-          
+
+      - name: Build chart dependencies
+        run: |
+          # chart-releaser resolves dependencies implicitly, but that resolution
+          # is unreliable for some external repos (open-webui), leaving the
+          # subchart missing at package time. Build them explicitly first so the
+          # vendored .tgz is present and packaging is deterministic.
+          for chart in charts/*/; do
+            if grep -q '^dependencies:' "${chart}Chart.yaml" 2>/dev/null; then
+              echo "Building dependencies for ${chart}"
+              helm dependency build "${chart}"
+            fi
+          done
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:


### PR DESCRIPTION
## Problem

`panda-chat 0.1.0` is **not in the chart index** — the `release` workflow has failed on every push to master since the chart merged:

```
Packaging chart 'charts/panda-chat'...
Error: found in Chart.yaml, but missing in charts/ directory: open-webui
```

#477 added `helm repo add open-webui` to the "Add repo dependencies" step, but that was not sufficient: chart-releaser's *implicit* dependency resolution still fails to vendor the `open-webui` subchart at package time (the bitnami `postgresql` dep used by `dora` resolves fine — this is specific to the open-webui repo). The chart itself is valid: `helm dependency build charts/panda-chat` succeeds locally with a clean Helm home, and the committed `Chart.lock` digest matches a fresh regeneration.

## Fix

Add an explicit **Build chart dependencies** step that runs `helm dependency build` for every chart with a `dependencies:` section before chart-releaser runs. This vendors the subchart `.tgz` deterministically, so `cr package` finds it present. Idempotent and a no-op for charts without deps.

## Effect

Once merged, the release workflow packages `panda-chat 0.1.0` and publishes it to `ethpandaops.github.io/ethereum-helm-charts` — unblocking the bal-devnets `generate_kubernetes_config` render (its `helm dependency update` needs the chart in the index).