### PR TITLE
fix(panda-chat): drop *.tgz from .helmignore so the chart publishes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,19 +34,6 @@ jobs:
           helm repo add chaos-mesh https://charts.chaos-mesh.org
           helm repo add open-webui https://helm.openwebui.com
 
-      - name: Build chart dependencies
-        run: |
-          # chart-releaser resolves dependencies implicitly, but that resolution
-          # is unreliable for some external repos (open-webui), leaving the
-          # subchart missing at package time. Build them explicitly first so the
-          # vendored .tgz is present and packaging is deterministic.
-          for chart in charts/*/; do
-            if grep -q '^dependencies:' "${chart}Chart.yaml" 2>/dev/null; then
-              echo "Building dependencies for ${chart}"
-              helm dependency build "${chart}"
-            fi
-          done
-
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
         with:

--- a/charts/panda-chat/.helmignore
+++ b/charts/panda-chat/.helmignore
@@ -2,7 +2,6 @@
 *.tmpl
 .git/
 .gitignore
-*.tgz
 .vscode/
 .idea/
 README.md.gotmpl

--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -3,9 +3,9 @@ name: panda-chat
 description: AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 home: https://github.com/ethpandaops/chat
 type: application
-version: 0.1.0
-# Hermes Agent upstream version baked into the panda-overlay image.
-appVersion: "0.11.0"
+version: 0.1.1
+# Hermes Agent upstream version (CalVer) baked into the panda-overlay image.
+appVersion: "2026.6.5"
 keywords:
   - llm
   - agent

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 


### PR DESCRIPTION
## Real root cause (supersedes #477 + #478)

The release workflow has failed on every push since panda-chat merged:
```
Packaging chart 'charts/panda-chat'...
Error: found in Chart.yaml, but missing in charts/ directory: open-webui
```

The actual cause: **`charts/panda-chat/.helmignore` listed `*.tgz`**. Helm applies `.helmignore` when packaging, so the vendored `open-webui-14.5.0.tgz` subchart was stripped out and the dependency check failed. `dora` and the other charts with deps ship fine precisely because their `.helmignore` has no `*.tgz` line. Reproduced + verified locally with the exact `cr` v1.7.0 binary (fails with the line, `Successfully packaged … panda-chat-0.1.1.tgz` without it).

## Changes
1. Remove `*.tgz` from `charts/panda-chat/.helmignore` — the fix.
2. Bump `version` 0.1.0 → **0.1.1** (0.1.0 never published; `ct lint` requires a bump for the changed chart) and set `appVersion` to the real CalVer Hermes tag **2026.6.5** (was a bogus `0.11.0`); regenerate README via helm-docs.
3. **Revert the "Build chart dependencies" step from #478** — chart-releaser already resolves the dep from the `open-webui` repo added to the workflow in #477 (confirmed locally: `cr package` self-resolves with no manual `helm dependency build`).

## Follow-up
The ansible `generate_kubernetes_config` registry pins `panda-chat 0.1.0`; that bumps to `0.1.1` on the ansible side once this publishes.