### PR TITLE
ci(test): package changed charts on PRs to catch release failures pre-merge

### DIFF
--- a/.github/scripts/package-changed-charts.sh
+++ b/.github/scripts/package-changed-charts.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Package every chart changed since a base ref, the same way the release
+# workflow does (helm dependency build + helm package).
+#
+# `ct lint` / `ct install` never package charts, so packaging-only failures —
+# e.g. a dependency stripped by a chart's .helmignore, or an unresolvable
+# dependency — otherwise surface only in the release job on master, after merge,
+# where they silently block publishing. Running this on the PR catches them.
+#
+# Usage: package-changed-charts.sh [base-ref]   # base-ref defaults to "master"
+set -euo pipefail
+
+base="${1:-master}"
+out="$(mktemp -d)"
+
+# Top-level chart directories touched since the base ref (e.g. "charts/dora").
+changed_charts() {
+  git diff --find-renames --name-only "$base" -- charts |
+    cut -d/ -f1-2 |
+    sort -u
+}
+
+# The external (http) repositories a chart declares as dependencies. These come
+# from the chart's own Chart.yaml, so there is no hardcoded repo list to keep in
+# sync as charts come and go.
+chart_dependency_repos() {
+  helm dependency list "$1" 2>/dev/null |
+    awk 'NR > 1 && $3 ~ /^https?:\/\// { print $3 }' |
+    sort -u
+}
+
+for chart in $(changed_charts); do
+  [[ -f "$chart/Chart.yaml" ]] || continue
+
+  while read -r repo; do
+    # The local repo name is arbitrary (helm resolves dependencies by URL); a
+    # hash of the URL keeps it unique and deterministic.
+    helm repo add "dep-$(cksum <<<"$repo" | cut -d' ' -f1)" "$repo" >/dev/null 2>&1 || true
+  done < <(chart_dependency_repos "$chart")
+
+  echo "==> Packaging $chart"
+  helm dependency build "$chart"
+  helm package "$chart" --destination "$out"
+done

--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -70,28 +70,10 @@ jobs:
           --config ct.yaml
           --target-branch ${{ github.event.repository.default_branch }}
 
-      # Package changed charts the same way release.yaml does. `ct lint`/`install`
-      # never package, so packaging-only failures (e.g. a dependency stripped by
-      # .helmignore) otherwise surface only on master, after merge. This catches
-      # them on the PR.
+      # Package changed charts the same way release.yaml does, so packaging-only
+      # failures are caught on the PR rather than on master after merge.
       - name: Verify charts package (mirrors release)
-        run: |
-          mkdir -p /tmp/cr-packages
-          changed=$(git diff --find-renames --name-only "${{ github.event.repository.default_branch }}" -- charts \
-            | awk -F/ 'NF>=2 {print $1"/"$2}' | sort -u)
-          for chart in $changed; do
-            [ -f "$chart/Chart.yaml" ] || continue
-            # Add each external dependency repo the chart itself declares, so there
-            # is no hardcoded repo list to keep in sync as charts come and go.
-            helm dependency list "$chart" 2>/dev/null \
-              | awk 'NR>1 && $3 ~ /^https?:\/\// {print $3}' | sort -u \
-              | while read -r url; do
-                  helm repo add "dep-$(printf '%s' "$url" | cksum | cut -d' ' -f1)" "$url" >/dev/null 2>&1 || true
-                done
-            echo "Packaging $chart"
-            helm dependency build "$chart"
-            helm package "$chart" --destination /tmp/cr-packages
-          done
+        run: .github/scripts/package-changed-charts.sh "${{ github.event.repository.default_branch }}"
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0

--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -76,16 +76,18 @@ jobs:
       # them on the PR.
       - name: Verify charts package (mirrors release)
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo add ethpandaops https://ethpandaops.github.io/ethereum-helm-charts
-          helm repo add bjw-s https://bjw-s-labs.github.io/helm-charts
-          helm repo add chaos-mesh https://charts.chaos-mesh.org
-          helm repo add open-webui https://helm.openwebui.com
           mkdir -p /tmp/cr-packages
           changed=$(git diff --find-renames --name-only "${{ github.event.repository.default_branch }}" -- charts \
             | awk -F/ 'NF>=2 {print $1"/"$2}' | sort -u)
           for chart in $changed; do
             [ -f "$chart/Chart.yaml" ] || continue
+            # Add each external dependency repo the chart itself declares, so there
+            # is no hardcoded repo list to keep in sync as charts come and go.
+            helm dependency list "$chart" 2>/dev/null \
+              | awk 'NR>1 && $3 ~ /^https?:\/\// {print $3}' | sort -u \
+              | while read -r url; do
+                  helm repo add "dep-$(printf '%s' "$url" | cksum | cut -d' ' -f1)" "$url" >/dev/null 2>&1 || true
+                done
             echo "Packaging $chart"
             helm dependency build "$chart"
             helm package "$chart" --destination /tmp/cr-packages

--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -75,7 +75,6 @@ jobs:
       # .helmignore) otherwise surface only on master, after merge. This catches
       # them on the PR.
       - name: Verify charts package (mirrors release)
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo add ethpandaops https://ethpandaops.github.io/ethereum-helm-charts
@@ -83,7 +82,10 @@ jobs:
           helm repo add chaos-mesh https://charts.chaos-mesh.org
           helm repo add open-webui https://helm.openwebui.com
           mkdir -p /tmp/cr-packages
-          for chart in $(ct list-changed --config ct.yaml --target-branch ${{ github.event.repository.default_branch }}); do
+          changed=$(git diff --find-renames --name-only "${{ github.event.repository.default_branch }}" -- charts \
+            | awk -F/ 'NF>=2 {print $1"/"$2}' | sort -u)
+          for chart in $changed; do
+            [ -f "$chart/Chart.yaml" ] || continue
             echo "Packaging $chart"
             helm dependency build "$chart"
             helm package "$chart" --destination /tmp/cr-packages

--- a/.github/workflows/test-charts.yaml
+++ b/.github/workflows/test-charts.yaml
@@ -70,6 +70,25 @@ jobs:
           --config ct.yaml
           --target-branch ${{ github.event.repository.default_branch }}
 
+      # Package changed charts the same way release.yaml does. `ct lint`/`install`
+      # never package, so packaging-only failures (e.g. a dependency stripped by
+      # .helmignore) otherwise surface only on master, after merge. This catches
+      # them on the PR.
+      - name: Verify charts package (mirrors release)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo add ethpandaops https://ethpandaops.github.io/ethereum-helm-charts
+          helm repo add bjw-s https://bjw-s-labs.github.io/helm-charts
+          helm repo add chaos-mesh https://charts.chaos-mesh.org
+          helm repo add open-webui https://helm.openwebui.com
+          mkdir -p /tmp/cr-packages
+          for chart in $(ct list-changed --config ct.yaml --target-branch ${{ github.event.repository.default_branch }}); do
+            echo "Packaging $chart"
+            helm dependency build "$chart"
+            helm package "$chart" --destination /tmp/cr-packages
+          done
+
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
         if: steps.list-changed.outputs.changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,16 @@ SHELL=/bin/bash
 UID := $(shell id -u)
 CURRENT_DIR := $(shell pwd)
 
-.PHONY: init lint docs clean
+.PHONY: init lint package docs clean
 
 init:
 	@pre-commit install
 
 lint:
 	@docker run --rm --workdir /workdir --volume "$(CURRENT_DIR):/workdir" -u $(UID) -e "HOME=/tmp" quay.io/helmpack/chart-testing:v3.13.0 sh -ac 'chown ${UID} .; exec ct lint --target-branch master'
+
+package:
+	@.github/scripts/package-changed-charts.sh
 
 docs:
 	@docker run --rm --volume "$(CURRENT_DIR):/helm-docs" -u $(UID) jnorwood/helm-docs:v1.5.0

--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ The [CT (Chart Testing)](https://github.com/helm/chart-testing) tool is used to 
 make lint
 ```
 
+### Publishing a chart
+
+Charts publish from `master` via the `release` workflow (`helm package` → GitHub Pages index). Before merging a chart change:
+
+- **Bump `version`** in `Chart.yaml` — `ct lint` rejects a changed chart without a version bump, and the release skips versions already published.
+- **Set a real `appVersion`** (the upstream app's actual version/tag).
+- **Regenerate the README** with `make docs` — it uses the pinned pre-commit helm-docs version; running a different one drifts the badges.
+- **Verify it packages**, the same way release does (CI now does this on PRs too):
+
+  ```sh
+  helm dependency build charts/<name> && helm package charts/<name> -d /tmp
+  ```
+
+  `ct lint`/`install` do **not** package, so packaging-only issues (e.g. a dependency stripped by `.helmignore`) only show up here.
+
 ## License
 
 [MIT License](LICENSE)


### PR DESCRIPTION
## Why

A chart can pass every PR check and still fail to **release**. `ct lint` and `ct install` never *package* charts:

| PR check | packages? |
|---|---|
| `ct lint` | ❌ |
| `ct install` (`helm install` from the chart dir) | ❌ |
| `release` (`helm package`, master only, post-merge) | ✅ |

So packaging-only failures — e.g. a dependency stripped by a chart's `.helmignore` — surface only on `master` after merge, where chart-releaser exits non-zero and the chart **silently never publishes**. (Exactly what happened to `panda-chat`.)

## Change

Add a **Verify charts package** step to the PR workflow that runs `helm dependency build` + `helm package` on each changed chart — the same operation `release.yaml` performs.

- Changed charts are enumerated via `git diff` (not `ct list-changed`, whose stdout is polluted with `>>>` trace lines).
- **No hardcoded repo list:** the dependency repos to add are read from each chart's own `helm dependency list`, so a new chart pulling a new repo is handled automatically — no workflow edit needed.
- No cluster required.

Also documents a short, generic chart-publish checklist in the README.

## Verified locally

- Clean chart (`dora`): auto-derives the bitnami repo and packages successfully.
- Chart with the `.helmignore` `*.tgz` bug: `helm package` errors (`missing in charts/ directory: open-webui`), step exits 1.

## Note

`release.yaml` still adds its dependency repos from a hardcoded list. That's pre-existing and out of scope here, but the same `helm dependency list`-derived approach could replace it in a follow-up so the release path is maintenance-free too.