### PR TITLE
feat(panda-chat)!: service-account bot identity + privileged sidecar split

### DIFF
--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -3,7 +3,7 @@ name: panda-chat
 description: AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 home: https://github.com/ethpandaops/chat
 type: application
-version: 0.1.1
+version: 0.2.0
 # Hermes Agent upstream version (CalVer) baked into the panda-overlay image.
 appVersion: "2026.6.5"
 keywords:

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 
@@ -28,8 +28,11 @@ AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResea
 
 When `panda.enabled` is true the agent pod runs `panda-server` + `dockerd`
 alongside Hermes and is **privileged** (dockerd needs root). The bot identity
-for the proxy is provisioned once (GitHub bot user + `panda auth login`) and
-its credentials are supplied via `credentials.panda.*`.
+for the proxy is an Authentik **service account** (e.g. `panda-chat-svc` with a
+non-expiring app password) supplied via `credentials.panda.botUsername` /
+`credentials.panda.botToken`. panda-server mints proxy access tokens on demand
+with the OAuth2 `client_credentials` grant and keeps them in memory only — no
+seeded credential files, no refresh-token rotation.
 
 ## Access control
 
@@ -64,9 +67,10 @@ SSO** (no password), auto-provisioning the user on first visit.
 
 Per-user identity is also propagated to the agent: the Open-WebUI image
 (`ethpandaops/open-webui-cf`) forwards `Cf-Access-Jwt-Assertion` upstream so
-Hermes sees the individual user (per-user auth on downstream resources + Langfuse
-attribution). On devnets the bal-devnets ansible template wires the trusted-header
-config from a single toggle — see `chat.yaml.j2`.
+Hermes can attribute traffic to the individual user (Langfuse `user_id`,
+`X-Panda-On-Behalf-Of` audit header). Authentication to panda-proxy itself is
+always the bot service account. On devnets the bal-devnets ansible template
+wires the trusted-header config from a single toggle — see `chat.yaml.j2`.
 
 ## Image
 
@@ -104,8 +108,8 @@ open-webui:
 | credentials.langfuse.publicKey | string | `""` | Langfuse public key (pk-lf-...) |
 | credentials.langfuse.secretKey | string | `""` | Langfuse secret key (sk-lf-...) |
 | credentials.llmApiKey | string | `""` | The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`) |
-| credentials.panda.credentialsFile | string | `""` | Filename panda expects under credentials/ (derived from issuer+client hash) |
-| credentials.panda.credentialsJson | string | `""` | panda-server bot credentials JSON (contents of credentials/<hash>.json) |
+| credentials.panda.botToken | string | `""` | Authentik app-password token for the bot service account (client_credentials grant; minted tokens stay in memory). Required when `panda.enabled`. |
+| credentials.panda.botUsername | string | `""` | Authentik service-account username for the bot (e.g. `panda-chat-svc`). Required when `panda.enabled`. |
 | devnetTools.faucet.enabled | bool | `true` | Enable the faucet (account funding) skill |
 | devnetTools.faucet.url | string | `""` | powfaucet base URL |
 | devnetTools.join.configUrl | string | `""` | Base config service URL (serves /cl/config.yaml, /el/enodes.txt, etc.) |
@@ -149,9 +153,9 @@ open-webui:
 | open-webui.sso.trustedHeader.nameHeader | string | `""` |  |
 | open-webui.websocket.enabled | bool | `false` |  |
 | open-webui.websocket.redis.enabled | bool | `false` |  |
-| panda.clientId | string | `"panda-proxy"` | OIDC client id at the proxy |
+| panda.clientId | string | `"panda-proxy"` | OAuth client id at the proxy |
 | panda.enabled | bool | `true` | Enable the panda sidecar processes + privileged pod |
-| panda.issuerUrl | string | `"https://dex.primary.production.platform.ethpandaops.io"` | OIDC issuer (Dex) the bot identity authenticates against |
+| panda.issuerUrl | string | `"https://authentik.analytics.production.platform.ethpandaops.io/application/o/panda-proxy/"` | Authentik application issuer the bot service account mints client_credentials tokens against (the trailing slash is part of the issuer — keep it) |
 | panda.proxyUrl | string | `"https://panda-proxy.analytics.production.platform.ethpandaops.io"` | Hosted panda-proxy URL (analytics data plane) |
 | panda.sandboxImage | string | `"ethpandaops/panda:sandbox-v0.31.0"` | Sandbox container image panda-server spawns for Python execution |
 | panda.storageDriver | string | `"overlay2"` | dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod) |

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.11.0](https://img.shields.io/badge/AppVersion-0.11.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 
@@ -26,13 +26,17 @@ AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResea
   `observability/langfuse` plugin — one span per turn, one generation per LLM
   call, one observation per tool call; traces tagged with the devnet name.
 
-When `panda.enabled` is true the agent pod runs `panda-server` + `dockerd`
-alongside Hermes and is **privileged** (dockerd needs root). The bot identity
-for the proxy is an Authentik **service account** (e.g. `panda-chat-svc` with a
+When `panda.enabled` is true the pod gains a separate **`panda-server`
+sidecar container** (`panda-server` + `dockerd`, privileged — dockerd needs
+root); the `hermes` container always runs unprivileged. The bot identity for
+the proxy is an Authentik **service account** (e.g. `panda-chat-svc` with a
 non-expiring app password) supplied via `credentials.panda.botUsername` /
-`credentials.panda.botToken`. panda-server mints proxy access tokens on demand
-with the OAuth2 `client_credentials` grant and keeps them in memory only — no
-seeded credential files, no refresh-token rotation.
+`credentials.panda.botToken` and materialized in a **dedicated Secret that only
+the sidecar mounts** — Hermes executes LLM-driven shell commands, so it never
+shares an environment with the bot credential. panda-server mints proxy access
+tokens on demand with the OAuth2 `client_credentials` grant and keeps them in
+memory only — no seeded credential files, no refresh-token rotation. Hermes
+reaches the sidecar on `127.0.0.1:2480` (shared pod network namespace).
 
 ## Access control
 
@@ -154,9 +158,10 @@ open-webui:
 | open-webui.websocket.enabled | bool | `false` |  |
 | open-webui.websocket.redis.enabled | bool | `false` |  |
 | panda.clientId | string | `"panda-proxy"` | OAuth client id at the proxy |
-| panda.enabled | bool | `true` | Enable the panda sidecar processes + privileged pod |
+| panda.enabled | bool | `true` | Enable the panda-server sidecar container (privileged; the hermes container is not) |
 | panda.issuerUrl | string | `"https://authentik.analytics.production.platform.ethpandaops.io/application/o/panda-proxy/"` | Authentik application issuer the bot service account mints client_credentials tokens against (the trailing slash is part of the issuer — keep it) |
 | panda.proxyUrl | string | `"https://panda-proxy.analytics.production.platform.ethpandaops.io"` | Hosted panda-proxy URL (analytics data plane) |
+| panda.resources | object | `{"limits":{"cpu":"2000m","memory":"4Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | Resources for the panda-server sidecar (panda-server + dockerd + sandboxes) |
 | panda.sandboxImage | string | `"ethpandaops/panda:sandbox-v0.31.0"` | Sandbox container image panda-server spawns for Python execution |
 | panda.storageDriver | string | `"overlay2"` | dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod) |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes |
@@ -164,7 +169,7 @@ open-webui:
 | persistence.existingClaim | string | `""` | Use an existing claim instead of creating one |
 | persistence.size | string | `"8Gi"` | PVC size |
 | persistence.storageClass | string | `""` | Storage class (cluster default when empty) |
-| resources | object | `{"limits":{"cpu":"3000m","memory":"6Gi"},"requests":{"cpu":"300m","memory":"1Gi"}}` | Resources for the agent pod (Hermes + panda-server + dockerd + sandboxes) |
+| resources | object | `{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"200m","memory":"768Mi"}}` | Resources for the hermes container (panda-server sidecar sized separately under `panda.resources`) |
 | service.port | int | `8642` | Agent service port (Hermes OpenAI-compatible API) |
 | service.type | string | `"ClusterIP"` | Agent service type |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |

--- a/charts/panda-chat/README.md.gotmpl
+++ b/charts/panda-chat/README.md.gotmpl
@@ -23,13 +23,17 @@
   `observability/langfuse` plugin — one span per turn, one generation per LLM
   call, one observation per tool call; traces tagged with the devnet name.
 
-When `panda.enabled` is true the agent pod runs `panda-server` + `dockerd`
-alongside Hermes and is **privileged** (dockerd needs root). The bot identity
-for the proxy is an Authentik **service account** (e.g. `panda-chat-svc` with a
+When `panda.enabled` is true the pod gains a separate **`panda-server`
+sidecar container** (`panda-server` + `dockerd`, privileged — dockerd needs
+root); the `hermes` container always runs unprivileged. The bot identity for
+the proxy is an Authentik **service account** (e.g. `panda-chat-svc` with a
 non-expiring app password) supplied via `credentials.panda.botUsername` /
-`credentials.panda.botToken`. panda-server mints proxy access tokens on demand
-with the OAuth2 `client_credentials` grant and keeps them in memory only — no
-seeded credential files, no refresh-token rotation.
+`credentials.panda.botToken` and materialized in a **dedicated Secret that only
+the sidecar mounts** — Hermes executes LLM-driven shell commands, so it never
+shares an environment with the bot credential. panda-server mints proxy access
+tokens on demand with the OAuth2 `client_credentials` grant and keeps them in
+memory only — no seeded credential files, no refresh-token rotation. Hermes
+reaches the sidecar on `127.0.0.1:2480` (shared pod network namespace).
 
 ## Access control
 

--- a/charts/panda-chat/README.md.gotmpl
+++ b/charts/panda-chat/README.md.gotmpl
@@ -25,8 +25,11 @@
 
 When `panda.enabled` is true the agent pod runs `panda-server` + `dockerd`
 alongside Hermes and is **privileged** (dockerd needs root). The bot identity
-for the proxy is provisioned once (GitHub bot user + `panda auth login`) and
-its credentials are supplied via `credentials.panda.*`.
+for the proxy is an Authentik **service account** (e.g. `panda-chat-svc` with a
+non-expiring app password) supplied via `credentials.panda.botUsername` /
+`credentials.panda.botToken`. panda-server mints proxy access tokens on demand
+with the OAuth2 `client_credentials` grant and keeps them in memory only — no
+seeded credential files, no refresh-token rotation.
 
 ## Access control
 
@@ -61,9 +64,10 @@ SSO** (no password), auto-provisioning the user on first visit.
 
 Per-user identity is also propagated to the agent: the Open-WebUI image
 (`ethpandaops/open-webui-cf`) forwards `Cf-Access-Jwt-Assertion` upstream so
-Hermes sees the individual user (per-user auth on downstream resources + Langfuse
-attribution). On devnets the bal-devnets ansible template wires the trusted-header
-config from a single toggle — see `chat.yaml.j2`.
+Hermes can attribute traffic to the individual user (Langfuse `user_id`,
+`X-Panda-On-Behalf-Of` audit header). Authentication to panda-proxy itself is
+always the bot service account. On devnets the bal-devnets ansible template
+wires the trusted-header config from a single toggle — see `chat.yaml.j2`.
 
 ## Image
 

--- a/charts/panda-chat/templates/_helpers.tpl
+++ b/charts/panda-chat/templates/_helpers.tpl
@@ -65,11 +65,20 @@ Agent image reference. Tag defaults to the chart appVersion.
 {{- end }}
 
 {{/*
-Secret holding the Hermes bearer (API_SERVER_KEY), the LLM model key and
-the panda bot credentials.
+Secret holding the Hermes bearer (API_SERVER_KEY) and the LLM model key.
+Mounted ONLY into the unprivileged hermes container.
 */}}
 {{- define "panda-chat.secretName" -}}
 {{- printf "%s-secret" (include "panda-chat.hermesFullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Secret holding the panda bot credentials (PANDA_BOT_USERNAME/TOKEN).
+Mounted ONLY into the panda-server sidecar — never into hermes, which
+executes LLM-driven shell commands and must not be able to read it.
+*/}}
+{{- define "panda-chat.pandaSecretName" -}}
+{{- printf "%s-panda-secret" (include "panda-chat.hermesFullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{- define "panda-chat.configMapName" -}}

--- a/charts/panda-chat/templates/configmap.yaml
+++ b/charts/panda-chat/templates/configmap.yaml
@@ -27,7 +27,10 @@ data:
         - observability/langfuse
     {{- end }}
   {{- if .Values.panda.enabled }}
-  # panda-server config — seeded to /opt/data/.config/panda/config.yaml (creds live in the Secret).
+  # panda-server config — seeded to /opt/data/.config/panda/config.yaml. The
+  # bot identity (PANDA_BOT_USERNAME / PANDA_BOT_TOKEN) lives in the Secret and
+  # is substituted from the environment by panda's config loader; access tokens
+  # are minted via client_credentials and never touch the PVC.
   panda-config.yaml: |
     server:
       host: "127.0.0.1"
@@ -46,7 +49,9 @@ data:
     proxy:
       url: {{ .Values.panda.proxyUrl | quote }}
       auth:
-        mode: "oidc"
+        mode: "client_credentials"
         issuer_url: {{ .Values.panda.issuerUrl | quote }}
         client_id: {{ .Values.panda.clientId | quote }}
+        username: "${PANDA_BOT_USERNAME}"
+        password: "${PANDA_BOT_TOKEN}"
   {{- end }}

--- a/charts/panda-chat/templates/deployment.yaml
+++ b/charts/panda-chat/templates/deployment.yaml
@@ -20,17 +20,11 @@ spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.panda.enabled }}
-      # panda: dockerd needs root, so only fsGroup applies (lets the init containers write the PVC).
+      # Per-container security contexts below; fsGroup lets every container
+      # (and the init containers) share the PVC. Hermes is ALWAYS unprivileged
+      # — only the panda-server sidecar is privileged (dockerd).
       securityContext:
         fsGroup: 10000
-      {{- else }}
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 10000
-        runAsGroup: 10000
-        fsGroup: 10000
-      {{- end }}
       initContainers:
         # Seed Hermes (and panda) config onto the PVC.
         - name: seed-config
@@ -62,19 +56,19 @@ spec:
         - name: hermes
           image: {{ include "panda-chat.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          {{- if .Values.panda.enabled }}
-          # privileged for dockerd; the image ENTRYPOINT starts dockerd + panda-server before Hermes.
+          # Unprivileged, always: this container executes LLM-driven shell
+          # commands. It carries no bot credentials and no docker socket; it
+          # reaches panda-server over 127.0.0.1 (shared pod netns).
           securityContext:
-            privileged: true
-          {{- else }}
-          securityContext:
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10000
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: false
             capabilities:
               drop: [ALL]
-          command: ["/opt/hermes/docker/entrypoint.sh"]
+          command: ["/opt/panda/entrypoint.sh"]
           args: ["gateway", "run"]
-          {{- end }}
           env:
             - {name: API_SERVER_HOST, value: "0.0.0.0"}
             - {name: API_SERVER_PORT, value: "8642"}
@@ -88,7 +82,6 @@ spec:
             - {name: HERMES_UID, value: "10000"}
             - {name: HERMES_GID, value: "10000"}
             {{- if .Values.panda.enabled }}
-            - {name: DOCKERD_STORAGE_DRIVER, value: {{ .Values.panda.storageDriver | quote }}}
             - {name: PANDA_SERVER_URL, value: "http://127.0.0.1:2480"}
             {{- end }}
             # Devnet context for the agent + skills.
@@ -108,30 +101,13 @@ spec:
             - {name: HERMES_LANGFUSE_ENV, value: {{ .Values.langfuse.env | default .Values.network | quote }}}
             {{- end }}
           envFrom:
+            # Hermes secret only (bearer, LLM key, langfuse) — the panda bot
+            # credential lives in its own Secret on the sidecar.
             - secretRef:
                 name: {{ include "panda-chat.secretName" . }}
                 optional: true
           ports:
             - {name: http, containerPort: 8642, protocol: TCP}
-          {{- if .Values.panda.enabled }}
-          # ~5 min budget: dockerd + sandbox image pull + panda-server + hermes.
-          startupProbe:
-            exec:
-              command:
-                - sh
-                - -c
-                - curl -sf http://127.0.0.1:2480/health && curl -sf http://127.0.0.1:8642/health
-            periodSeconds: 5
-            failureThreshold: 60
-          readinessProbe:
-            httpGet: {path: /health, port: http}
-            initialDelaySeconds: 60
-            periodSeconds: 5
-          livenessProbe:
-            httpGet: {path: /health, port: http}
-            initialDelaySeconds: 120
-            periodSeconds: 30
-          {{- else }}
           readinessProbe:
             httpGet: {path: /health, port: http}
             initialDelaySeconds: 10
@@ -140,11 +116,40 @@ spec:
             httpGet: {path: /health, port: http}
             initialDelaySeconds: 30
             periodSeconds: 30
-          {{- end }}
           resources: {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - {name: data, mountPath: /opt/data}
             - {name: config, mountPath: /config-src, readOnly: true}
+        {{- if .Values.panda.enabled }}
+        # panda-server + dockerd sidecar. Privileged (dockerd) and the ONLY
+        # container holding the bot credential. Same image, "panda-stack" arg.
+        - name: panda-server
+          image: {{ include "panda-chat.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: true
+          command: ["/opt/panda/entrypoint.sh"]
+          args: ["panda-stack"]
+          env:
+            - {name: DOCKERD_STORAGE_DRIVER, value: {{ .Values.panda.storageDriver | quote }}}
+          envFrom:
+            - secretRef:
+                name: {{ include "panda-chat.pandaSecretName" . }}
+          # exec probes: panda-server binds 127.0.0.1, which kubelet httpGet
+          # (pod IP) can't reach. ~5 min budget: dockerd + sandbox pull + server.
+          startupProbe:
+            exec:
+              command: ["sh", "-c", "curl -sf http://127.0.0.1:2480/health"]
+            periodSeconds: 5
+            failureThreshold: 60
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "curl -sf http://127.0.0.1:2480/health"]
+            periodSeconds: 30
+          resources: {{- toYaml .Values.panda.resources | nindent 12 }}
+          volumeMounts:
+            - {name: data, mountPath: /opt/data}
+        {{- end }}
       volumes:
         - name: config
           configMap:

--- a/charts/panda-chat/templates/deployment.yaml
+++ b/charts/panda-chat/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
               [ -f /data/config.yaml ] && old=$(sha256sum /data/config.yaml | cut -d' ' -f1)
               [ "$new" != "$old" ] && cp /config-src/config.yaml /data/config.yaml || true
               {{- if .Values.panda.enabled }}
-              mkdir -p /data/.config/panda/credentials /data/panda-storage
+              mkdir -p /data/.config/panda /data/panda-storage
               cp /config-src/panda-config.yaml /data/.config/panda/config.yaml
               {{- end }}
           volumeMounts:
@@ -58,33 +58,6 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ALL]
-        {{- if .Values.panda.enabled }}
-        # Seed panda bot credentials from the Secret (refreshed every pod start).
-        - name: seed-panda-creds
-          image: busybox:1.37
-          command: ["sh", "-c"]
-          args:
-            - |
-              set -eu
-              mkdir -p /data/.config/panda/credentials
-              if [ -n "${PANDA_CREDENTIALS_JSON:-}" ] && [ -n "${PANDA_CREDENTIALS_FILE:-}" ]; then
-                printf '%s' "$PANDA_CREDENTIALS_JSON" \
-                  > "/data/.config/panda/credentials/${PANDA_CREDENTIALS_FILE}"
-              fi
-          envFrom:
-            - secretRef:
-                name: {{ include "panda-chat.secretName" . }}
-                optional: true
-          volumeMounts:
-            - {name: data, mountPath: /data}
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 10000
-            runAsGroup: 10000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: [ALL]
-        {{- end }}
       containers:
         - name: hermes
           image: {{ include "panda-chat.image" . }}

--- a/charts/panda-chat/templates/secret.yaml
+++ b/charts/panda-chat/templates/secret.yaml
@@ -1,7 +1,8 @@
 {{/*
 Holds: API_SERVER_KEY (Hermes bearer, generated once and preserved),
-<llm.apiKeyEnv> (model key), PANDA_CREDENTIALS_* (panda bot creds)
-and HERMES_LANGFUSE_* (tracing keys).
+<llm.apiKeyEnv> (model key), PANDA_BOT_USERNAME / PANDA_BOT_TOKEN (the
+Authentik service-account identity panda-server mints client_credentials
+tokens with) and HERMES_LANGFUSE_* (tracing keys).
 */}}
 {{- $secretName := include "panda-chat.secretName" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
@@ -24,12 +25,8 @@ stringData:
   {{ $.Values.llm.apiKeyEnv }}: {{ . | quote }}
   {{- end }}
   {{- if .Values.panda.enabled }}
-  {{- with .Values.credentials.panda.credentialsJson }}
-  PANDA_CREDENTIALS_JSON: {{ . | quote }}
-  {{- end }}
-  {{- with .Values.credentials.panda.credentialsFile }}
-  PANDA_CREDENTIALS_FILE: {{ . | quote }}
-  {{- end }}
+  PANDA_BOT_USERNAME: {{ required "credentials.panda.botUsername is required when panda.enabled" .Values.credentials.panda.botUsername | quote }}
+  PANDA_BOT_TOKEN: {{ required "credentials.panda.botToken is required when panda.enabled" .Values.credentials.panda.botToken | quote }}
   {{- end }}
   {{- if .Values.langfuse.enabled }}
   {{- with .Values.credentials.langfuse.publicKey }}

--- a/charts/panda-chat/templates/secret.yaml
+++ b/charts/panda-chat/templates/secret.yaml
@@ -1,8 +1,14 @@
 {{/*
-Holds: API_SERVER_KEY (Hermes bearer, generated once and preserved),
-<llm.apiKeyEnv> (model key), PANDA_BOT_USERNAME / PANDA_BOT_TOKEN (the
-Authentik service-account identity panda-server mints client_credentials
-tokens with) and HERMES_LANGFUSE_* (tracing keys).
+Two Secrets with a deliberate trust boundary between them:
+
+- <hermes>-secret: API_SERVER_KEY (Hermes bearer, generated once and
+  preserved), <llm.apiKeyEnv> (model key) and HERMES_LANGFUSE_* (tracing
+  keys). envFrom'd ONLY into the unprivileged hermes container.
+- <hermes>-panda-secret: PANDA_BOT_USERNAME / PANDA_BOT_TOKEN (the
+  Authentik service-account identity panda-server mints client_credentials
+  tokens with). envFrom'd ONLY into the panda-server sidecar. Hermes
+  executes LLM-driven shell commands, so it must never share an
+  environment (or container) with the bot credential.
 */}}
 {{- $secretName := include "panda-chat.secretName" . -}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
@@ -24,10 +30,6 @@ stringData:
   {{- with .Values.credentials.llmApiKey }}
   {{ $.Values.llm.apiKeyEnv }}: {{ . | quote }}
   {{- end }}
-  {{- if .Values.panda.enabled }}
-  PANDA_BOT_USERNAME: {{ required "credentials.panda.botUsername is required when panda.enabled" .Values.credentials.panda.botUsername | quote }}
-  PANDA_BOT_TOKEN: {{ required "credentials.panda.botToken is required when panda.enabled" .Values.credentials.panda.botToken | quote }}
-  {{- end }}
   {{- if .Values.langfuse.enabled }}
   {{- with .Values.credentials.langfuse.publicKey }}
   HERMES_LANGFUSE_PUBLIC_KEY: {{ . | quote }}
@@ -36,3 +38,15 @@ stringData:
   HERMES_LANGFUSE_SECRET_KEY: {{ . | quote }}
   {{- end }}
   {{- end }}
+{{- if .Values.panda.enabled }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "panda-chat.pandaSecretName" . }}
+  labels: {{- include "panda-chat.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  PANDA_BOT_USERNAME: {{ required "credentials.panda.botUsername is required when panda.enabled" .Values.credentials.panda.botUsername | quote }}
+  PANDA_BOT_TOKEN: {{ required "credentials.panda.botToken is required when panda.enabled" .Values.credentials.panda.botToken | quote }}
+{{- end }}

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -49,9 +49,11 @@ panda:
   enabled: true
   # -- Hosted panda-proxy URL (analytics data plane)
   proxyUrl: "https://panda-proxy.analytics.production.platform.ethpandaops.io"
-  # -- OIDC issuer (Dex) the bot identity authenticates against
-  issuerUrl: "https://dex.primary.production.platform.ethpandaops.io"
-  # -- OIDC client id at the proxy
+  # -- Authentik application issuer the bot service account mints
+  # client_credentials tokens against (the trailing slash is part of the
+  # issuer — keep it)
+  issuerUrl: "https://authentik.analytics.production.platform.ethpandaops.io/application/o/panda-proxy/"
+  # -- OAuth client id at the proxy
   clientId: "panda-proxy"
   # -- Sandbox container image panda-server spawns for Python execution
   sandboxImage: "ethpandaops/panda:sandbox-v0.31.0"
@@ -90,10 +92,13 @@ credentials:
   # -- The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`)
   llmApiKey: ""
   panda:
-    # -- panda-server bot credentials JSON (contents of credentials/<hash>.json)
-    credentialsJson: ""
-    # -- Filename panda expects under credentials/ (derived from issuer+client hash)
-    credentialsFile: ""
+    # -- Authentik service-account username for the bot (e.g. `panda-chat-svc`).
+    # Required when `panda.enabled`.
+    botUsername: ""
+    # -- Authentik app-password token for the bot service account
+    # (client_credentials grant; minted tokens stay in memory). Required when
+    # `panda.enabled`.
+    botToken: ""
   langfuse:
     # -- Langfuse public key (pk-lf-...)
     publicKey: ""

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -43,9 +43,11 @@ systemPrompt: |
   skill, and join the network with the `join-devnet` skill. Be concise and
   always scope data queries to this devnet.
 
-# Panda integration. When enabled the agent pod runs panda-server + dockerd and is privileged.
+# Panda integration. When enabled the pod gains a separate privileged
+# "panda-server" sidecar container (panda-server + dockerd) holding the bot
+# credential; the hermes container stays unprivileged and credential-free.
 panda:
-  # -- Enable the panda sidecar processes + privileged pod
+  # -- Enable the panda-server sidecar container (privileged; the hermes container is not)
   enabled: true
   # -- Hosted panda-proxy URL (analytics data plane)
   proxyUrl: "https://panda-proxy.analytics.production.platform.ethpandaops.io"
@@ -59,6 +61,14 @@ panda:
   sandboxImage: "ethpandaops/panda:sandbox-v0.31.0"
   # -- dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod)
   storageDriver: overlay2
+  # -- Resources for the panda-server sidecar (panda-server + dockerd + sandboxes)
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: 2000m
+      memory: 4Gi
 
 # LLM-call tracing via Hermes' bundled observability/langfuse plugin.
 # Keys come from credentials.langfuse; fail-open if absent.
@@ -105,14 +115,14 @@ credentials:
     # -- Langfuse secret key (sk-lf-...)
     secretKey: ""
 
-# -- Resources for the agent pod (Hermes + panda-server + dockerd + sandboxes)
+# -- Resources for the hermes container (panda-server sidecar sized separately under `panda.resources`)
 resources:
   requests:
-    cpu: 300m
-    memory: 1Gi
+    cpu: 200m
+    memory: 768Mi
   limits:
-    cpu: 3000m
-    memory: 6Gi
+    cpu: 1000m
+    memory: 2Gi
 
 persistence:
   # -- Enable a PVC for /opt/data (Hermes state + panda config/creds/storage)


### PR DESCRIPTION
## Summary

Chart 0.1.0 → 0.2.0, two breaking changes (design: ethpandaops/chat `docs/identity-and-attribution-plan.md`):

**1. Bot identity via Authentik `client_credentials`** (replaces seeded refresh-token credentials):
- `credentials.panda.{credentialsJson,credentialsFile}` → `{botUsername,botToken}` (both `required` when `panda.enabled`)
- `panda-config.yaml` renders a `proxy.auth` block with `mode: client_credentials` against the Authentik issuer (trailing slash is part of the issuer); Dex default removed
- `seed-panda-creds` initContainer deleted — tokens are minted on demand and live in memory only

**2. Container split — hermes is never privileged:**
- `hermes` container: always unprivileged (uid 10000, caps dropped), no docker socket, no bot credential
- `panda-server` sidecar (only when `panda.enabled`): privileged (dockerd), same image with `panda-stack` entrypoint arg, and the ONLY container that mounts the new dedicated `<name>-panda-secret` (`PANDA_BOT_USERNAME`/`PANDA_BOT_TOKEN`). Hermes executes LLM-driven shell commands, so it must never share an environment with the credential.
- Hermes reaches the sidecar on `127.0.0.1:2480` (shared pod netns); sidecar probes are exec-based (server binds loopback)
- Resources split: `.resources` → hermes, `panda.resources` → sidecar

Requires the `hermes-agent-panda` image with the dispatch entrypoint (ethpandaops/chat) built on a panda release that includes client_credentials (ethpandaops/panda#170) — do not roll to a devnet before both exist.

## Verification

- `helm template` (panda enabled): hermes `privileged=False runAsUser=10000 envFrom=[hermes-secret]`; panda-server `privileged=True envFrom=[panda-secret]`; secrets carry the right keys
- `helm template` (panda disabled): single unprivileged container, no panda Secret
- Missing `botUsername`/`botToken` fails with a clear `required` error
- The client_credentials chain itself was live-tested against staging Authentik + proxy with the panda-ci service account (mint, cache reuse, ClickHouse query through the proxy)
- README regenerated via helm-docs