### PR TITLE
feat(panda-chat): client_credentials bot auth, drop credential-file seeding

### DIFF
--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -3,7 +3,7 @@ name: panda-chat
 description: AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 home: https://github.com/ethpandaops/chat
 type: application
-version: 0.1.1
+version: 0.2.0
 # Hermes Agent upstream version (CalVer) baked into the panda-overlay image.
 appVersion: "2026.6.5"
 keywords:

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 
@@ -104,8 +104,7 @@ open-webui:
 | credentials.langfuse.publicKey | string | `""` | Langfuse public key (pk-lf-...) |
 | credentials.langfuse.secretKey | string | `""` | Langfuse secret key (sk-lf-...) |
 | credentials.llmApiKey | string | `""` | The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`) |
-| credentials.panda.credentialsFile | string | `""` | Filename panda expects under credentials/ (derived from issuer+client hash) |
-| credentials.panda.credentialsJson | string | `""` | panda-server bot credentials JSON (contents of credentials/<hash>.json) |
+| credentials.panda.botToken | string | `""` | Service-account app password for the client_credentials grant (panda-server mints short-lived proxy tokens from it, in memory only) |
 | devnetTools.faucet.enabled | bool | `true` | Enable the faucet (account funding) skill |
 | devnetTools.faucet.url | string | `""` | powfaucet base URL |
 | devnetTools.join.configUrl | string | `""` | Base config service URL (serves /cl/config.yaml, /el/enodes.txt, etc.) |
@@ -151,10 +150,11 @@ open-webui:
 | open-webui.websocket.redis.enabled | bool | `false` |  |
 | panda.clientId | string | `"panda-proxy"` | OIDC client id at the proxy |
 | panda.enabled | bool | `true` | Enable the panda sidecar processes + privileged pod |
-| panda.issuerUrl | string | `"https://dex.primary.production.platform.ethpandaops.io"` | OIDC issuer (Dex) the bot identity authenticates against |
+| panda.issuerUrl | string | `"https://authentik.analytics.production.platform.ethpandaops.io/application/o/panda-proxy/"` | OIDC issuer the bot identity mints client_credentials tokens against |
 | panda.proxyUrl | string | `"https://panda-proxy.analytics.production.platform.ethpandaops.io"` | Hosted panda-proxy URL (analytics data plane) |
 | panda.sandboxImage | string | `"ethpandaops/panda:sandbox-v0.31.0"` | Sandbox container image panda-server spawns for Python execution |
 | panda.storageDriver | string | `"overlay2"` | dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod) |
+| panda.username | string | `"panda-chat-svc"` | Service-account username for the client_credentials grant |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes |
 | persistence.enabled | bool | `true` | Enable a PVC for /opt/data (Hermes state + panda config/creds/storage) |
 | persistence.existingClaim | string | `""` | Use an existing claim instead of creating one |

--- a/charts/panda-chat/templates/configmap.yaml
+++ b/charts/panda-chat/templates/configmap.yaml
@@ -27,7 +27,10 @@ data:
         - observability/langfuse
     {{- end }}
   {{- if .Values.panda.enabled }}
-  # panda-server config — seeded to /opt/data/.config/panda/config.yaml (creds live in the Secret).
+  # panda-server config — seeded to /opt/data/.config/panda/config.yaml. The app
+  # password reaches the process as PANDA_BOT_TOKEN (Secret env); panda's config
+  # loader substitutes ${PANDA_BOT_TOKEN} at load time, and access tokens minted
+  # from it stay in memory — no credential files.
   panda-config.yaml: |
     server:
       host: "127.0.0.1"
@@ -46,7 +49,9 @@ data:
     proxy:
       url: {{ .Values.panda.proxyUrl | quote }}
       auth:
-        mode: "oidc"
+        mode: "client_credentials"
         issuer_url: {{ .Values.panda.issuerUrl | quote }}
         client_id: {{ .Values.panda.clientId | quote }}
+        username: {{ .Values.panda.username | quote }}
+        password: "${PANDA_BOT_TOKEN}"
   {{- end }}

--- a/charts/panda-chat/templates/deployment.yaml
+++ b/charts/panda-chat/templates/deployment.yaml
@@ -58,33 +58,6 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ALL]
-        {{- if .Values.panda.enabled }}
-        # Seed panda bot credentials from the Secret (refreshed every pod start).
-        - name: seed-panda-creds
-          image: busybox:1.37
-          command: ["sh", "-c"]
-          args:
-            - |
-              set -eu
-              mkdir -p /data/.config/panda/credentials
-              if [ -n "${PANDA_CREDENTIALS_JSON:-}" ] && [ -n "${PANDA_CREDENTIALS_FILE:-}" ]; then
-                printf '%s' "$PANDA_CREDENTIALS_JSON" \
-                  > "/data/.config/panda/credentials/${PANDA_CREDENTIALS_FILE}"
-              fi
-          envFrom:
-            - secretRef:
-                name: {{ include "panda-chat.secretName" . }}
-                optional: true
-          volumeMounts:
-            - {name: data, mountPath: /data}
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 10000
-            runAsGroup: 10000
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop: [ALL]
-        {{- end }}
       containers:
         - name: hermes
           image: {{ include "panda-chat.image" . }}

--- a/charts/panda-chat/templates/secret.yaml
+++ b/charts/panda-chat/templates/secret.yaml
@@ -1,6 +1,6 @@
 {{/*
 Holds: API_SERVER_KEY (Hermes bearer, generated once and preserved),
-<llm.apiKeyEnv> (model key), PANDA_CREDENTIALS_* (panda bot creds)
+<llm.apiKeyEnv> (model key), PANDA_BOT_TOKEN (panda bot app password)
 and HERMES_LANGFUSE_* (tracing keys).
 */}}
 {{- $secretName := include "panda-chat.secretName" . -}}
@@ -24,11 +24,8 @@ stringData:
   {{ $.Values.llm.apiKeyEnv }}: {{ . | quote }}
   {{- end }}
   {{- if .Values.panda.enabled }}
-  {{- with .Values.credentials.panda.credentialsJson }}
-  PANDA_CREDENTIALS_JSON: {{ . | quote }}
-  {{- end }}
-  {{- with .Values.credentials.panda.credentialsFile }}
-  PANDA_CREDENTIALS_FILE: {{ . | quote }}
+  {{- with .Values.credentials.panda.botToken }}
+  PANDA_BOT_TOKEN: {{ . | quote }}
   {{- end }}
   {{- end }}
   {{- if .Values.langfuse.enabled }}

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -49,10 +49,12 @@ panda:
   enabled: true
   # -- Hosted panda-proxy URL (analytics data plane)
   proxyUrl: "https://panda-proxy.analytics.production.platform.ethpandaops.io"
-  # -- OIDC issuer (Dex) the bot identity authenticates against
-  issuerUrl: "https://dex.primary.production.platform.ethpandaops.io"
+  # -- OIDC issuer the bot identity mints client_credentials tokens against
+  issuerUrl: "https://authentik.analytics.production.platform.ethpandaops.io/application/o/panda-proxy/"
   # -- OIDC client id at the proxy
   clientId: "panda-proxy"
+  # -- Service-account username for the client_credentials grant
+  username: "panda-chat-svc"
   # -- Sandbox container image panda-server spawns for Python execution
   sandboxImage: "ethpandaops/panda:sandbox-v0.31.0"
   # -- dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod)
@@ -90,10 +92,9 @@ credentials:
   # -- The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`)
   llmApiKey: ""
   panda:
-    # -- panda-server bot credentials JSON (contents of credentials/<hash>.json)
-    credentialsJson: ""
-    # -- Filename panda expects under credentials/ (derived from issuer+client hash)
-    credentialsFile: ""
+    # -- Service-account app password for the client_credentials grant
+    # (panda-server mints short-lived proxy tokens from it, in memory only)
+    botToken: ""
   langfuse:
     # -- Langfuse public key (pk-lf-...)
     publicKey: ""


### PR DESCRIPTION
Switches the panda sidecar to the OAuth2 `client_credentials` grant shipped in panda v0.32 (ethpandaops/panda#170): panda-server mints short-lived proxy tokens from an Authentik service-account app password and keeps them in memory — no more seeded credential files or 30-day refresh-token rotation.

- `panda.issuerUrl` default → the Authentik issuer (was Dex); new `panda.username` (default `panda-chat-svc`)
- `credentials.panda.{credentialsJson,credentialsFile}` → `credentials.panda.botToken` (lands in the Secret as `PANDA_BOT_TOKEN`; panda's config loader substitutes `${PANDA_BOT_TOKEN}` at load)
- `seed-panda-creds` init container removed
- chart `0.1.1` → `0.2.0`

The bot identity (`panda-chat-svc` + app password) is already live and verified in staging and production Authentik (platform#355 + promote). Provisioning runbook: ethpandaops/chat `docs/panda-bot-setup.md`.

Verified: `helm lint` clean; `helm template` renders the client_credentials auth block, the Secret key, and no stale `PANDA_CREDENTIALS_*`/init-container references.