### PR TITLE
fix(panda-chat): stable API_SERVER_KEY bearer to survive ArgoCD (0.3.0)

### DIFF
--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -3,7 +3,7 @@ name: panda-chat
 description: AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 home: https://github.com/ethpandaops/chat
 type: application
-version: 0.2.0
+version: 0.3.0
 # Hermes Agent upstream version (CalVer) baked into the panda-overlay image.
 appVersion: "2026.6.5"
 keywords:

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -177,5 +177,5 @@ open-webui:
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Create a service account for the agent |
 | serviceAccount.name | string | `""` | Service account name (defaults to the fullname) |
-| systemPrompt | string | `"You are the EthPandaOps assistant for the Ethereum devnet \"{{ network }}\".\nHelp users understand devnet state and use the EthPandaOps tooling:\nquery live data with the `panda` skill, fund accounts with the `faucet`\nskill, and join the network with the `join-devnet` skill. Be concise and\nalways scope data queries to this devnet.\n"` | System prompt for the agent. `{{ network }}` is substituted at render time. |
+| systemPrompt | string | `"You are the EthPandaOps assistant for the Ethereum devnet \"{{ network }}\", scoped to it alone.\nTools: `panda` (query live data), `faucet` (fund accounts), `join-devnet` (join the network).\nDiscover before querying (the `panda` skill shows how); never invent APIs, tables, or node names.\nReport exactly what the tools return — never fabricate; if data is missing or sources disagree, say so.\nLead with the numbers, in plain English. Be concise.\n"` | System prompt for the agent. `{{ network }}` is substituted at render time. |
 | tolerations | list | `[]` | Tolerations for the agent pod |

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 
@@ -109,6 +109,7 @@ open-webui:
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for the agent pod |
 | chainId | string | `""` | The devnet chain id (informational; surfaced to the join-devnet skill). |
+| credentials.apiServerKey | string | `""` | Stable OW<->Hermes bearer (`API_SERVER_KEY`). Leave empty for a bare `helm install` (auto-generated + preserved). Under GitOps/ArgoCD you MUST set this to a stable value (sops) — `helm template` can't preserve a generated one, so an empty value drifts OW and Hermes apart on re-render. |
 | credentials.langfuse.publicKey | string | `""` | Langfuse public key (pk-lf-...) |
 | credentials.langfuse.secretKey | string | `""` | Langfuse secret key (sk-lf-...) |
 | credentials.llmApiKey | string | `""` | The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`) |

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -27,16 +27,18 @@ AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResea
   call, one observation per tool call; traces tagged with the devnet name.
 
 When `panda.enabled` is true the pod gains a separate **`panda-server`
-sidecar container** (`panda-server` + `dockerd`, privileged — dockerd needs
-root); the `hermes` container always runs unprivileged. The bot identity for
-the proxy is an Authentik **service account** (e.g. `panda-chat-svc` with a
-non-expiring app password) supplied via `credentials.panda.botUsername` /
-`credentials.panda.botToken` and materialized in a **dedicated Secret that only
-the sidecar mounts** — Hermes executes LLM-driven shell commands, so it never
-shares an environment with the bot credential. panda-server mints proxy access
-tokens on demand with the OAuth2 `client_credentials` grant and keeps them in
-memory only — no seeded credential files, no refresh-token rotation. Hermes
-reaches the sidecar on `127.0.0.1:2480` (shared pod network namespace).
+sidecar container**; both containers run **unprivileged**. The sandbox is the
+`direct` backend — executed Python runs as a subprocess inside the panda-server
+container, isolated by the Kubernetes pod boundary (no dockerd, no sandbox
+image, no privilege). The bot identity for the proxy is an Authentik **service
+account** (e.g. `panda-chat-svc` with a non-expiring app password) supplied via
+`credentials.panda.botUsername` / `credentials.panda.botToken` and materialized
+in a **dedicated Secret that only the sidecar mounts** — Hermes executes
+LLM-driven shell commands, so it never shares an environment with the bot
+credential. panda-server mints proxy access tokens on demand with the OAuth2
+`client_credentials` grant and keeps them in memory only — no seeded credential
+files, no refresh-token rotation. Hermes reaches the sidecar on
+`127.0.0.1:2480` (shared pod network namespace).
 
 ## Access control
 
@@ -81,7 +83,8 @@ wires the trusted-header config from a single toggle — see `chat.yaml.j2`.
 Two images, both built from [`ethpandaops/chat`](https://github.com/ethpandaops/chat):
 
 - `image.repository` (`ethpandaops/hermes-agent-panda`) — the Hermes agent
-  with the panda overlay (panda CLI + panda-server + dockerd + entrypoint + skills).
+  with the panda overlay (panda CLI + panda-server + sandbox Python env +
+  entrypoint + skills).
 - `open-webui.image` (`ethpandaops/open-webui-cf`) — Open-WebUI patched to
   forward the Cloudflare Access JWT to the agent (see [Access control](#access-control)).
   Its tag must match the `open-webui` subchart appVersion.
@@ -123,7 +126,7 @@ open-webui:
 | devnetTools.join.rpcUrl | string | `""` | Public execution RPC URL |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ethpandaops/hermes-agent-panda"` | Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server + dockerd). |
+| image.repository | string | `"ethpandaops/hermes-agent-panda"` | Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server). |
 | image.tag | string | `""` | Image tag. Defaults to the chart appVersion when empty. |
 | imagePullSecrets | list | `[]` | Image pull secrets for the agent image |
 | langfuse.baseUrl | string | `""` | Langfuse base URL |
@@ -159,12 +162,10 @@ open-webui:
 | open-webui.websocket.enabled | bool | `false` |  |
 | open-webui.websocket.redis.enabled | bool | `false` |  |
 | panda.clientId | string | `"panda-proxy"` | OAuth client id at the proxy |
-| panda.enabled | bool | `true` | Enable the panda-server sidecar container (privileged; the hermes container is not) |
+| panda.enabled | bool | `true` | Enable the panda-server sidecar container (holds the bot credential) |
 | panda.issuerUrl | string | `"https://authentik.analytics.production.platform.ethpandaops.io/application/o/panda-proxy/"` | Authentik application issuer the bot service account mints client_credentials tokens against (the trailing slash is part of the issuer — keep it) |
 | panda.proxyUrl | string | `"https://panda-proxy.analytics.production.platform.ethpandaops.io"` | Hosted panda-proxy URL (analytics data plane) |
-| panda.resources | object | `{"limits":{"cpu":"2000m","memory":"4Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | Resources for the panda-server sidecar (panda-server + dockerd + sandboxes) |
-| panda.sandboxImage | string | `"ethpandaops/panda:sandbox-v0.31.0"` | Sandbox container image panda-server spawns for Python execution |
-| panda.storageDriver | string | `"overlay2"` | dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod) |
+| panda.resources | object | `{"limits":{"cpu":"1000m","memory":"2Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | Resources for the panda-server sidecar |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes |
 | persistence.enabled | bool | `true` | Enable a PVC for /opt/data (Hermes state + panda config/creds/storage) |
 | persistence.existingClaim | string | `""` | Use an existing claim instead of creating one |

--- a/charts/panda-chat/README.md.gotmpl
+++ b/charts/panda-chat/README.md.gotmpl
@@ -24,16 +24,18 @@
   call, one observation per tool call; traces tagged with the devnet name.
 
 When `panda.enabled` is true the pod gains a separate **`panda-server`
-sidecar container** (`panda-server` + `dockerd`, privileged — dockerd needs
-root); the `hermes` container always runs unprivileged. The bot identity for
-the proxy is an Authentik **service account** (e.g. `panda-chat-svc` with a
-non-expiring app password) supplied via `credentials.panda.botUsername` /
-`credentials.panda.botToken` and materialized in a **dedicated Secret that only
-the sidecar mounts** — Hermes executes LLM-driven shell commands, so it never
-shares an environment with the bot credential. panda-server mints proxy access
-tokens on demand with the OAuth2 `client_credentials` grant and keeps them in
-memory only — no seeded credential files, no refresh-token rotation. Hermes
-reaches the sidecar on `127.0.0.1:2480` (shared pod network namespace).
+sidecar container**; both containers run **unprivileged**. The sandbox is the
+`direct` backend — executed Python runs as a subprocess inside the panda-server
+container, isolated by the Kubernetes pod boundary (no dockerd, no sandbox
+image, no privilege). The bot identity for the proxy is an Authentik **service
+account** (e.g. `panda-chat-svc` with a non-expiring app password) supplied via
+`credentials.panda.botUsername` / `credentials.panda.botToken` and materialized
+in a **dedicated Secret that only the sidecar mounts** — Hermes executes
+LLM-driven shell commands, so it never shares an environment with the bot
+credential. panda-server mints proxy access tokens on demand with the OAuth2
+`client_credentials` grant and keeps them in memory only — no seeded credential
+files, no refresh-token rotation. Hermes reaches the sidecar on
+`127.0.0.1:2480` (shared pod network namespace).
 
 ## Access control
 
@@ -78,7 +80,8 @@ wires the trusted-header config from a single toggle — see `chat.yaml.j2`.
 Two images, both built from [`ethpandaops/chat`](https://github.com/ethpandaops/chat):
 
 - `image.repository` (`ethpandaops/hermes-agent-panda`) — the Hermes agent
-  with the panda overlay (panda CLI + panda-server + dockerd + entrypoint + skills).
+  with the panda overlay (panda CLI + panda-server + sandbox Python env +
+  entrypoint + skills).
 - `open-webui.image` (`ethpandaops/open-webui-cf`) — Open-WebUI patched to
   forward the Cloudflare Access JWT to the agent (see [Access control](#access-control)).
   Its tag must match the `open-webui` subchart appVersion.

--- a/charts/panda-chat/templates/NOTES.txt
+++ b/charts/panda-chat/templates/NOTES.txt
@@ -25,6 +25,7 @@ release name). Set these on the open-webui subchart:
 
 {{- if .Values.panda.enabled }}
 
-Panda is ENABLED — the agent pod is privileged and runs dockerd + panda-server.
+Panda is ENABLED — the pod runs an unprivileged panda-server sidecar (the
+`direct` sandbox executes Python as a subprocess; no dockerd, no privilege).
 Provision the bot identity and fill credentials.panda.* (see the chart README).
 {{- end }}

--- a/charts/panda-chat/templates/configmap.yaml
+++ b/charts/panda-chat/templates/configmap.yaml
@@ -30,20 +30,18 @@ data:
   # panda-server config — seeded to /opt/data/.config/panda/config.yaml. The
   # bot identity (PANDA_BOT_USERNAME / PANDA_BOT_TOKEN) lives in the Secret and
   # is substituted from the environment by panda's config loader; access tokens
-  # are minted via client_credentials and never touch the PVC.
+  # are minted via client_credentials and never touch the PVC. The sandbox
+  # backend is "direct" — Python runs as a subprocess inside the panda-server
+  # container, relying on the Kubernetes pod boundary for isolation. No dockerd,
+  # no sandbox image, no privileged container needed.
   panda-config.yaml: |
     server:
       host: "127.0.0.1"
       port: 2480
       base_url: "http://127.0.0.1:2480"
-      sandbox_url: "http://172.17.0.1:2480"
     sandbox:
-      backend: docker
-      image: {{ .Values.panda.sandboxImage | quote }}
-      network: "bridge"
+      backend: direct
       timeout: 300
-      memory_limit: "1g"
-      cpu_limit: 1.0
     storage:
       base_dir: "/opt/data/panda-storage"
     proxy:

--- a/charts/panda-chat/templates/deployment.yaml
+++ b/charts/panda-chat/templates/deployment.yaml
@@ -121,27 +121,32 @@ spec:
             - {name: data, mountPath: /opt/data}
             - {name: config, mountPath: /config-src, readOnly: true}
         {{- if .Values.panda.enabled }}
-        # panda-server + dockerd sidecar. Privileged (dockerd) and the ONLY
-        # container holding the bot credential. Same image, "panda-stack" arg.
+        # panda-server sidecar. Runs unprivileged — the `direct` sandbox
+        # backend executes Python as a subprocess inside the container,
+        # relying on the Kubernetes pod boundary for isolation. No dockerd,
+        # no sandbox image, no privileged container.
         - name: panda-server
           image: {{ include "panda-chat.image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            privileged: true
+            runAsNonRoot: true
+            runAsUser: 10000
+            runAsGroup: 10000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: [ALL]
           command: ["/opt/panda/entrypoint.sh"]
           args: ["panda-stack"]
-          env:
-            - {name: DOCKERD_STORAGE_DRIVER, value: {{ .Values.panda.storageDriver | quote }}}
           envFrom:
             - secretRef:
                 name: {{ include "panda-chat.pandaSecretName" . }}
           # exec probes: panda-server binds 127.0.0.1, which kubelet httpGet
-          # (pod IP) can't reach. ~5 min budget: dockerd + sandbox pull + server.
+          # (pod IP) can't reach.
           startupProbe:
             exec:
               command: ["sh", "-c", "curl -sf http://127.0.0.1:2480/health"]
             periodSeconds: 5
-            failureThreshold: 60
+            failureThreshold: 12
           livenessProbe:
             exec:
               command: ["sh", "-c", "curl -sf http://127.0.0.1:2480/health"]

--- a/charts/panda-chat/templates/deployment.yaml
+++ b/charts/panda-chat/templates/deployment.yaml
@@ -21,8 +21,9 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}
       # Per-container security contexts below; fsGroup lets every container
-      # (and the init containers) share the PVC. Hermes is ALWAYS unprivileged
-      # — only the panda-server sidecar is privileged (dockerd).
+      # (and the init containers) share the PVC. Both containers run
+      # unprivileged — the panda-server `direct` sandbox executes Python as a
+      # subprocess, isolated by the pod boundary (no dockerd, no privilege).
       securityContext:
         fsGroup: 10000
       initContainers:
@@ -142,11 +143,18 @@ spec:
                 name: {{ include "panda-chat.pandaSecretName" . }}
           # exec probes: panda-server binds 127.0.0.1, which kubelet httpGet
           # (pod IP) can't reach.
+          # Generous startup budget (20 min): the EIP semantic index (9k chunks)
+          # is built at boot via the hosted proxy's embedding endpoint. When the
+          # proxy's Redis cache is unreachable EVERY chunk is a cache miss, so a
+          # cold boot re-embeds everything (~10 min observed) — plus first-run
+          # EIP/spec/schema fetches. A tight budget kills panda-server mid-embed
+          # → restart → re-embed → loop. (The real fix is the proxy Redis; this
+          # just lets a cold boot finish.)
           startupProbe:
             exec:
               command: ["sh", "-c", "curl -sf http://127.0.0.1:2480/health"]
-            periodSeconds: 5
-            failureThreshold: 12
+            periodSeconds: 10
+            failureThreshold: 120
           livenessProbe:
             exec:
               command: ["sh", "-c", "curl -sf http://127.0.0.1:2480/health"]

--- a/charts/panda-chat/templates/secret.yaml
+++ b/charts/panda-chat/templates/secret.yaml
@@ -1,21 +1,33 @@
 {{/*
 Two Secrets with a deliberate trust boundary between them:
 
-- <hermes>-secret: API_SERVER_KEY (Hermes bearer, generated once and
-  preserved), <llm.apiKeyEnv> (model key) and HERMES_LANGFUSE_* (tracing
-  keys). envFrom'd ONLY into the unprivileged hermes container.
+- <hermes>-secret: API_SERVER_KEY (Hermes bearer, see below), <llm.apiKeyEnv>
+  (model key) and HERMES_LANGFUSE_* (tracing keys). envFrom'd ONLY into the
+  unprivileged hermes container.
 - <hermes>-panda-secret: PANDA_BOT_USERNAME / PANDA_BOT_TOKEN (the
   Authentik service-account identity panda-server mints client_credentials
   tokens with). envFrom'd ONLY into the panda-server sidecar. Hermes
   executes LLM-driven shell commands, so it must never share an
   environment (or container) with the bot credential.
 */}}
+{{/*
+API_SERVER_KEY (OW <-> Hermes bearer) resolution, in priority order:
+  1. credentials.apiServerKey — an explicit, STABLE value. GitOps supplies it
+     from sops; this is the only source that survives ArgoCD, whose client-side
+     `helm template` has no cluster connection (see 2).
+  2. lookup-preserve of the existing in-cluster Secret. Works under a direct
+     `helm upgrade`, but is a NO-OP under ArgoCD — so it must not be the only
+     source, or every re-render mints a fresh bearer and OW/Hermes drift apart.
+  3. randAlphaNum — first-install fallback for a bare `helm install`.
+*/}}
 {{- $secretName := include "panda-chat.secretName" . -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
-{{- $bearer := "" -}}
-{{- if and $existing $existing.data -}}
-  {{- with index $existing.data "API_SERVER_KEY" -}}
-    {{- $bearer = . | b64dec -}}
+{{- $bearer := .Values.credentials.apiServerKey -}}
+{{- if not $bearer -}}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+  {{- if and $existing $existing.data -}}
+    {{- with index $existing.data "API_SERVER_KEY" -}}
+      {{- $bearer = . | b64dec -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- if not $bearer -}}{{- $bearer = randAlphaNum 40 -}}{{- end -}}

--- a/charts/panda-chat/templates/service.yaml
+++ b/charts/panda-chat/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "panda-chat.hermesFullname" . }}
   labels: {{- include "panda-chat.labels" . | nindent 4 }}
 spec:
+  publishNotReadyAddresses: true
   type: {{ .Values.service.type }}
   selector: {{- include "panda-chat.selectorLabels" . | nindent 4 }}
   ports:

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -12,7 +12,7 @@ network: ""
 chainId: ""
 
 image:
-  # -- Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server + dockerd).
+  # -- Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server).
   repository: ethpandaops/hermes-agent-panda
   # -- Image tag. Defaults to the chart appVersion when empty.
   tag: ""
@@ -37,17 +37,18 @@ llm:
 
 # -- System prompt for the agent. `{{ network }}` is substituted at render time.
 systemPrompt: |
-  You are the EthPandaOps assistant for the Ethereum devnet "{{ network }}".
-  Help users understand devnet state and use the EthPandaOps tooling:
-  query live data with the `panda` skill, fund accounts with the `faucet`
-  skill, and join the network with the `join-devnet` skill. Be concise and
-  always scope data queries to this devnet.
+  You are the EthPandaOps assistant for the Ethereum devnet "{{ network }}", scoped to it alone.
+  Tools: `panda` (query live data), `faucet` (fund accounts), `join-devnet` (join the network).
+  Discover before querying (the `panda` skill shows how); never invent APIs, tables, or node names.
+  Report exactly what the tools return — never fabricate; if data is missing or sources disagree, say so.
+  Lead with the numbers, in plain English. Be concise.
 
-# Panda integration. When enabled the pod gains a separate privileged
-# "panda-server" sidecar container (panda-server + dockerd) holding the bot
-# credential; the hermes container stays unprivileged and credential-free.
+# Panda integration. When enabled the pod gains a separate "panda-server"
+# sidecar container holding the bot credential; the hermes container stays
+# credential-free. Both run unprivileged — the `direct` sandbox runs Python as
+# a subprocess, isolated by the pod boundary (no dockerd, no privilege).
 panda:
-  # -- Enable the panda-server sidecar container (privileged; the hermes container is not)
+  # -- Enable the panda-server sidecar container (holds the bot credential)
   enabled: true
   # -- Hosted panda-proxy URL (analytics data plane)
   proxyUrl: "https://panda-proxy.analytics.production.platform.ethpandaops.io"

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -99,6 +99,11 @@ devnetTools:
 
 # Credentials. Injected via vals `<path:...>` on devnets; set directly for standalone use.
 credentials:
+  # -- Stable OW<->Hermes bearer (`API_SERVER_KEY`). Leave empty for a bare
+  # `helm install` (auto-generated + preserved). Under GitOps/ArgoCD you MUST
+  # set this to a stable value (sops) — `helm template` can't preserve a
+  # generated one, so an empty value drifts OW and Hermes apart on re-render.
+  apiServerKey: ""
   # -- The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`)
   llmApiKey: ""
   panda:

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -57,18 +57,14 @@ panda:
   issuerUrl: "https://authentik.analytics.production.platform.ethpandaops.io/application/o/panda-proxy/"
   # -- OAuth client id at the proxy
   clientId: "panda-proxy"
-  # -- Sandbox container image panda-server spawns for Python execution
-  sandboxImage: "ethpandaops/panda:sandbox-v0.31.0"
-  # -- dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod)
-  storageDriver: overlay2
-  # -- Resources for the panda-server sidecar (panda-server + dockerd + sandboxes)
+  # -- Resources for the panda-server sidecar
   resources:
     requests:
       cpu: 200m
       memory: 512Mi
     limits:
-      cpu: 2000m
-      memory: 4Gi
+      cpu: 1000m
+      memory: 2Gi
 
 # LLM-call tracing via Hermes' bundled observability/langfuse plugin.
 # Keys come from credentials.langfuse; fail-open if absent.


### PR DESCRIPTION
## Problem
The OW<->Hermes bearer (`API_SERVER_KEY`) was minted with `randAlphaNum` guarded by a `lookup`-preserve. Under **ArgoCD** that guard is a no-op — Argo renders with client-side `helm template` (no cluster connection), so `lookup` returns nil and a **fresh bearer is minted on every re-render**. Whichever of the OW / Hermes pods doesn't restart is stranded on the old key → Hermes `/v1/models` 401s → **empty model picker** (observed live on bal-devnet-7).

## Fix
Resolve `API_SERVER_KEY` as **`credentials.apiServerKey` → lookup-preserve → random**, in that order. GitOps supplies a stable value (sops); the lookup+random path stays only as the bare `helm install` fallback. Both OW and Hermes already read the same Secret object, so a stable value means permanent agreement.

- `secret.yaml`: priority-ordered bearer resolution (documented inline)
- `values.yaml`: new `credentials.apiServerKey`
- bumps chart **0.2.0 → 0.3.0**; README regenerated (helm-docs v1.5.0)

Paired with ansible-collection-general#548 (`credentials.apiServerKey` ← `services.enc.yaml#chat.api_server_key`).