### PR TITLE
feat(powfaucet): make concurrency-limit and recurring-limits matching configurable

### DIFF
--- a/charts/powfaucet/Chart.yaml
+++ b/charts/powfaucet/Chart.yaml
@@ -6,7 +6,7 @@ home: https://github.com/pk910/PoWFaucet
 sources:
   - https://github.com/pk910/PoWFaucet
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "2.5.0"
 maintainers:
   - name: pk910

--- a/charts/powfaucet/README.md
+++ b/charts/powfaucet/README.md
@@ -1,7 +1,7 @@
 
 # powfaucet
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 PoW Faucet for EVM chains
 
@@ -57,6 +57,10 @@ faucetPowRewardPerHash: 500000000000000000 # 0.5 ETH
 | faucetCaptchaProvider | string | `"hcaptcha"` | Captcha module: provider (hcaptcha / recaptcha) |
 | faucetCaptchaSecret | string | `"0xCensoredHCaptchaSecretKey"` | Captcha module: provider secret |
 | faucetCaptchaSitekey | string | `"00000000-0000-0000-0000-000000000000"` | Captcha module: provider site key |
+| faucetConcurrencyByAddrOnly | bool | `false` | Concurrency module: only check concurrency by target address (set true when a trusted proxy fronts the faucet, so all traffic shares one IP) |
+| faucetConcurrencyByIPOnly | bool | `false` | Concurrency module: only check concurrency by IP address (setting both ByAddrOnly and ByIPOnly skips both checks, disabling the module) |
+| faucetConcurrencyLimit | int | `1` | Concurrency module: max sessions in 'running' state at the same time for the same IP / target address |
+| faucetConcurrencyLimitEnabled | bool | `true` | Enable concurrency-limit module (cap simultaneously running sessions) |
 | faucetEnsEnabled | bool | `true` | Enable ENS module |
 | faucetEnsRequired | bool | `false` | ENS module: enforce ens name to use the faucet |
 | faucetEnsRpcUrl | string | `"https://rpc.flashbots.net/"` | ENS module: rpc url (mainnet) |
@@ -94,6 +98,7 @@ faucetPowRewardPerHash: 500000000000000000 # 0.5 ETH
 | faucetPowRewardPerHash | int | `500000000000000000` | PoW module: drop amount per eligible hash |
 | faucetPrivkey | string | `"feedbeef12340000feedbeef12340000feedbeef12340000feedbeef12340000"` | Faucet wallet private key |
 | faucetRecurringLimitsAmountWei | float | `100000000000000000000` | Recurring module: max amount a recurring user is allowed to request in total |
+| faucetRecurringLimitsByAddrOnly | bool | `false` | Recurring module: only match previous sessions by target address, not by IP (set true when a trusted proxy fronts the faucet, so all traffic shares one IP and a per-IP match becomes a global budget) |
 | faucetRecurringLimitsDuration | int | `86400` | Recurring module: aggregation duration for the max request amount check |
 | faucetRecurringLimitsEnabled | bool | `true` | Enable recurring module (enforce limits for recurring users) |
 | faucetRpcEndpoints | list | `[]` | Faucet el node rpc endpoints (multi-RPC mode). When non-empty, replaces faucetRpcUrl. Each entry supports: url (string, required; may include user:pass@), name (optional display label), priority (higher = preferred, default 1), metered (bool, throttles monitoring requests, default false). |
@@ -103,7 +108,7 @@ faucetPowRewardPerHash: 500000000000000000 # 0.5 ETH
 | faucetRpcUrl | string | `"http://your-el-node:8545"` | Faucet el node rpc (single endpoint legacy mode; ignored when faucetRpcEndpoints is set) |
 | faucetTitle | string | `"PoW Faucet"` | Faucet title |
 | faucetTxBroadcastCount | int | `2` | Number of highest-priority ready endpoints to broadcast each transaction to in parallel. At least one successful submission is required; other endpoints' errors (e.g. "already known") are ignored. |
-| faucetTxGasLimit | int | `21000` | Transaction gas limit |
+| faucetTxGasLimit | string | `nil` | Transaction gas limit (unset omits the setting so the faucet's built-in default applies; set explicitly only for networks with different gas rules, e.g. L2s) |
 | faucetTxMaxFee | int | `100000000000` | Max transaction gas fee (in wei) |
 | faucetTxMaxPrioFee | int | `2000000000` | Max transaction priority fee (in wei) |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |

--- a/charts/powfaucet/README.md
+++ b/charts/powfaucet/README.md
@@ -108,7 +108,6 @@ faucetPowRewardPerHash: 500000000000000000 # 0.5 ETH
 | faucetRpcUrl | string | `"http://your-el-node:8545"` | Faucet el node rpc (single endpoint legacy mode; ignored when faucetRpcEndpoints is set) |
 | faucetTitle | string | `"PoW Faucet"` | Faucet title |
 | faucetTxBroadcastCount | int | `2` | Number of highest-priority ready endpoints to broadcast each transaction to in parallel. At least one successful submission is required; other endpoints' errors (e.g. "already known") are ignored. |
-| faucetTxGasLimit | string | `nil` | Transaction gas limit (unset omits the setting so the faucet's built-in default applies; set explicitly only for networks with different gas rules, e.g. L2s) |
 | faucetTxMaxFee | int | `100000000000` | Max transaction gas fee (in wei) |
 | faucetTxMaxPrioFee | int | `2000000000` | Max transaction priority fee (in wei) |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |

--- a/charts/powfaucet/values.yaml
+++ b/charts/powfaucet/values.yaml
@@ -210,8 +210,8 @@ faucetExplorerLink: "https://your-el-block-explorer.com/tx/{txid}"
 # -- Additional html to show on the faucet page
 faucetHomeHtml: ""
 
-# -- Transaction gas limit
-faucetTxGasLimit: 21000
+# -- Transaction gas limit (unset omits the setting so the faucet's built-in default applies; set explicitly only for networks with different gas rules, e.g. L2s)
+faucetTxGasLimit: null
 
 # -- Max transaction gas fee (in wei)
 faucetTxMaxFee: 100000000000
@@ -366,6 +366,21 @@ faucetRecurringLimitsAmountWei: 100000000000000000000 # 100 ETH
 # -- Recurring module: aggregation duration for the max request amount check
 faucetRecurringLimitsDuration: 86400 # 1 day
 
+# -- Recurring module: only match previous sessions by target address, not by IP (set true when a trusted proxy fronts the faucet, so all traffic shares one IP and a per-IP match becomes a global budget)
+faucetRecurringLimitsByAddrOnly: false
+
+# -- Enable concurrency-limit module (cap simultaneously running sessions)
+faucetConcurrencyLimitEnabled: true
+
+# -- Concurrency module: max sessions in 'running' state at the same time for the same IP / target address
+faucetConcurrencyLimit: 1
+
+# -- Concurrency module: only check concurrency by target address (set true when a trusted proxy fronts the faucet, so all traffic shares one IP)
+faucetConcurrencyByAddrOnly: false
+
+# -- Concurrency module: only check concurrency by IP address (setting both ByAddrOnly and ByIPOnly skips both checks, disabling the module)
+faucetConcurrencyByIPOnly: false
+
 # -- Enable PoW module (require mining)
 faucetPowEnabled: false
 
@@ -466,7 +481,9 @@ config: |
 
   # transaction gas limit
   # use 21000 to prevent transactions to contracts
+  {{- if .Values.faucetTxGasLimit }}
   ethTxGasLimit: {{ .Values.faucetTxGasLimit }}
+  {{- end }}
 
   # use legacy (non-eip1559) transaction type
   # true: Type 0 (Legacy Transactions), false: Type 2 (EIP1559 Transactions)
@@ -682,15 +699,18 @@ config: |
       limits: # array of individual limits, which all need to be passed
         - limitAmount: {{ .Values.faucetRecurringLimitsAmountWei }}
           duration: {{ .Values.faucetRecurringLimitsDuration }}
+          {{- if .Values.faucetRecurringLimitsByAddrOnly }}
+          byAddrOnly: true # only match previous sessions by target address (trusted proxy shares one IP)
+          {{- end }}
 
     ## Concurrency Limit module
     concurrency-limit:
       # enable / disable concurrency limit
-      enabled: true
+      enabled: {{ .Values.faucetConcurrencyLimitEnabled }}
 
-      concurrencyLimit: 1 # only allow 1 concurrent session (sessions in 'running' state at the same time for the same ip / target addr)
-      byAddrOnly: false # only check concurrency by target address
-      byIPOnly: false # only check concurrency by IP address
+      concurrencyLimit: {{ .Values.faucetConcurrencyLimit }} # only allow N concurrent sessions (sessions in 'running' state at the same time for the same ip / target addr)
+      byAddrOnly: {{ .Values.faucetConcurrencyByAddrOnly }} # only check concurrency by target address
+      byIPOnly: {{ .Values.faucetConcurrencyByIPOnly }} # only check concurrency by IP address
       #messageByAddr: "" # custom error message when limit is exceeded by same target address
       #messageByIP: "" # custom error message when limit is exceeded by same IP address
 

--- a/charts/powfaucet/values.yaml
+++ b/charts/powfaucet/values.yaml
@@ -210,9 +210,6 @@ faucetExplorerLink: "https://your-el-block-explorer.com/tx/{txid}"
 # -- Additional html to show on the faucet page
 faucetHomeHtml: ""
 
-# -- Transaction gas limit (unset omits the setting so the faucet's built-in default applies; set explicitly only for networks with different gas rules, e.g. L2s)
-faucetTxGasLimit: null
-
 # -- Max transaction gas fee (in wei)
 faucetTxMaxFee: 100000000000
 
@@ -479,8 +476,8 @@ config: |
   # erc20 = ERC20 token
   faucetCoinType: "native"
 
-  # transaction gas limit
-  # use 21000 to prevent transactions to contracts
+  # transaction gas limit (only rendered when faucetTxGasLimit is set;
+  # otherwise the faucet's built-in default applies)
   {{- if .Values.faucetTxGasLimit }}
   ethTxGasLimit: {{ .Values.faucetTxGasLimit }}
   {{- end }}


### PR DESCRIPTION
## What

Expose the powfaucet `concurrency-limit` module's settings and a `recurring-limits` matching toggle as chart values, and stop hardcoding the transaction gas limit:

| value | default | meaning |
|---|---|---|
| `faucetConcurrencyLimitEnabled` | `true` | enable/disable the concurrency-limit module |
| `faucetConcurrencyLimit` | `1` | max simultaneous running sessions per IP / target addr |
| `faucetConcurrencyByAddrOnly` | `false` | only check concurrency by target address |
| `faucetConcurrencyByIPOnly` | `false` | only check concurrency by IP address |
| `faucetRecurringLimitsByAddrOnly` | `false` | only match previous sessions by target address |
| `faucetTxGasLimit` | *(undeclared)* | **`ethTxGasLimit` is only rendered when this is set** — the faucet's built-in default applies otherwise; define it only for networks with different gas rules (e.g. L2s) |

Chart `version` bumped `1.0.0` → `1.1.0`.

## Why

**byAddrOnly toggles** — both modules match sessions by target address **or** IP. When a trusted proxy fronts the faucet, every request carries the proxy's IP, so:
- **concurrency-limit** (hardcoded `concurrencyLimit: 1` by IP + addr) collapses to a **single running session globally** — one user mid-claim blocks everyone else's `startSession`.
- **recurring-limits** (`getFinishedSessions` matches `TargetAddr = ? OR RemoteIP LIKE ?`) turns the per-user recurring amount into a **global daily budget** — once collectively exhausted, every user is blocked for the rest of the window.

The `byAddrOnly` toggles keep the still-meaningful per-address protections while dropping the proxy-IP collapse.

**Gas limit** — the chart hardcoded `ethTxGasLimit: 21000`, which every consumer has to override the moment gas rules change (a plain transfer creating the recipient account costs ~207k under Amsterdam rules — measured 207,391 via `eth_estimateGas`). The app is the right owner of the sane default; the chart now omits the setting unless explicitly overridden. Note: the value must be omitted rather than rendered as `0` — PoWFaucet uses `gasLimit || config.ethTxGasLimit`, so a literal 0 would send 0-gas transactions.

## Compatibility

- Concurrency/recurring defaults preserve the exact previous rendering — verified with `helm template`.
- `faucetTxGasLimit` behavior change: deployments relying on the chart's old `21000` default now get the app default instead (more gas headroom, same recipient set — the faucet still only sends drops). Anyone who set the value explicitly is unaffected.

