### PR TITLE
feat(panda-chat): DinD sandbox + stable bearer, reliable overlay2 (0.3.1)

### DIFF
--- a/charts/panda-chat/Chart.lock
+++ b/charts/panda-chat/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: open-webui
   repository: https://helm.openwebui.com
-  version: 14.5.0
-digest: sha256:aa5b5a49cbbb030450d1578c6b87fe19faf724c19b1ddcb4d7af10b5c3be0f0d
-generated: "2026-06-02T16:50:10.322329968+02:00"
+  version: 15.2.0
+digest: sha256:f1c4204192d9aa4c581a1a15032e26eca0ac87626281d1ffc8953103eadaf08f
+generated: "2026-07-07T09:52:25.592857844+02:00"

--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -3,7 +3,7 @@ name: panda-chat
 description: AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 home: https://github.com/ethpandaops/chat
 type: application
-version: 0.3.0
+version: 0.3.1
 # Hermes Agent upstream version (CalVer) baked into the panda-overlay image.
 appVersion: "2026.6.5"
 keywords:

--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -3,7 +3,7 @@ name: panda-chat
 description: AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 home: https://github.com/ethpandaops/chat
 type: application
-version: 0.2.0
+version: 0.3.0
 # Hermes Agent upstream version (CalVer) baked into the panda-overlay image.
 appVersion: "2026.6.5"
 keywords:

--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/ethpandaops/chat
 type: application
 version: 0.3.2
 # Hermes Agent upstream version (CalVer) baked into the panda-overlay image.
-appVersion: "2026.6.5"
+appVersion: "2026.7.1"
 keywords:
   - llm
   - agent

--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -20,6 +20,6 @@ dependencies:
   # Front end. Rendered under the `open-webui` values key. Talks to the
   # in-chart Hermes agent over its OpenAI-compatible endpoint.
   - name: open-webui
-    version: "14.5.0"
+    version: "15.2.0"
     repository: "https://helm.openwebui.com"
     condition: open-webui.enabled

--- a/charts/panda-chat/Chart.yaml
+++ b/charts/panda-chat/Chart.yaml
@@ -3,7 +3,7 @@ name: panda-chat
 description: AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 home: https://github.com/ethpandaops/chat
 type: application
-version: 0.3.1
+version: 0.3.2
 # Hermes Agent upstream version (CalVer) baked into the panda-overlay image.
 appVersion: "2026.6.5"
 keywords:

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 
@@ -115,12 +115,14 @@ open-webui:
 | credentials.llmApiKey | string | `""` | The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`) |
 | credentials.panda.botToken | string | `""` | Authentik app-password token for the bot service account (client_credentials grant; minted tokens stay in memory). Required when `panda.enabled`. |
 | credentials.panda.botUsername | string | `""` | Authentik service-account username for the bot (e.g. `panda-chat-svc`). Required when `panda.enabled`. |
+| credentials.telegram.botToken | string | `""` | BotFather bot token (`<id>:<secret>`). Required when `telegram.enabled`. Materialized in the hermes Secret as TELEGRAM_BOT_TOKEN, which is what switches the gateway's telegram adapter on. |
 | devnetTools.faucet.enabled | bool | `true` | Enable the faucet (account funding) skill |
 | devnetTools.faucet.url | string | `""` | powfaucet base URL |
 | devnetTools.join.configUrl | string | `""` | Base config service URL (serves /cl/config.yaml, /el/enodes.txt, etc.) |
 | devnetTools.join.enabled | bool | `true` | Enable the join-devnet skill |
 | devnetTools.join.explorerUrl | string | `""` | Block explorer URL |
 | devnetTools.join.rpcUrl | string | `""` | Public execution RPC URL |
+| devnetTools.observability | object | `{}` | Observability tools DEPLOYED for this devnet (name -> URL), e.g. {dora: "...", forky: "...", tracoor: "...", assertoor: "..."}. Declared by the deployment pipeline and injected as DEVNET_TOOL_URLS into the agent's context briefing — the agent never probes or guesses tool URLs. |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
 | image.repository | string | `"ethpandaops/hermes-agent-panda"` | Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server + dockerd). |
@@ -177,5 +179,9 @@ open-webui:
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.create | bool | `true` | Create a service account for the agent |
 | serviceAccount.name | string | `""` | Service account name (defaults to the fullname) |
-| systemPrompt | string | `"You are the EthPandaOps assistant for the Ethereum devnet \"{{ network }}\".\nHelp users understand devnet state and use the EthPandaOps tooling:\nquery live data with the `panda` skill, fund accounts with the `faucet`\nskill, and join the network with the `join-devnet` skill. Be concise and\nalways scope data queries to this devnet.\n"` | System prompt for the agent. `{{ network }}` is substituted at render time. |
+| systemPrompt | string | facts card (see values.yaml) | System prompt for the agent. `{{ network }}` and `{{ chainId }}` are substituted at render time; points the agent at the pre-loaded /opt/data/devnet-context.md briefing. |
+| telegram.allowedChats | list | `[]` | Telegram chat ids allowed as DM chats (optional) |
+| telegram.allowedUsers | string | `""` | Numeric Telegram user ids allowed to DM the bot (comma-separated string) |
+| telegram.enabled | bool | `false` | Enable the Telegram gateway (requires credentials.telegram.botToken). The adapter long-polls Telegram — no ingress/webhook; Cloudflare Access stays untouched. |
+| telegram.groupAllowedChats | list | `[]` | Telegram group chat ids the bot may serve (optional) |
 | tolerations | list | `[]` | Tolerations for the agent pod |

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 
@@ -109,6 +109,7 @@ open-webui:
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity for the agent pod |
 | chainId | string | `""` | The devnet chain id (informational; surfaced to the join-devnet skill). |
+| credentials.apiServerKey | string | `""` | Stable OW<->Hermes bearer (`API_SERVER_KEY`). Leave empty for a bare `helm install` (auto-generated + preserved). Under GitOps/ArgoCD you MUST set this to a stable value (sops) — `helm template` can't preserve a generated one, so an empty value drifts OW and Hermes apart on re-render. |
 | credentials.langfuse.publicKey | string | `""` | Langfuse public key (pk-lf-...) |
 | credentials.langfuse.secretKey | string | `""` | Langfuse secret key (sk-lf-...) |
 | credentials.llmApiKey | string | `""` | The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`) |

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
+![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 
@@ -162,9 +162,10 @@ open-webui:
 | panda.enabled | bool | `true` | Enable the panda-server sidecar container (privileged; the hermes container is not) |
 | panda.issuerUrl | string | `"https://authentik.analytics.production.platform.ethpandaops.io/application/o/panda-proxy/"` | Authentik application issuer the bot service account mints client_credentials tokens against (the trailing slash is part of the issuer — keep it) |
 | panda.proxyUrl | string | `"https://panda-proxy.analytics.production.platform.ethpandaops.io"` | Hosted panda-proxy URL (analytics data plane) |
+| panda.dockerStorage | object | `{}` | emptyDir spec for dockerd's /var/lib/docker (the sandbox layer cache). Node-local so overlay2 works; ephemeral (re-pulled on cold start). Cap it with `sizeLimit: 10Gi`, or set `medium: ""` explicitly; {} = node default. |
 | panda.resources | object | `{"limits":{"cpu":"2000m","memory":"4Gi"},"requests":{"cpu":"200m","memory":"512Mi"}}` | Resources for the panda-server sidecar (panda-server + dockerd + sandboxes) |
-| panda.sandboxImage | string | `"ethpandaops/panda:sandbox-v0.31.0"` | Sandbox container image panda-server spawns for Python execution |
-| panda.storageDriver | string | `"overlay2"` | dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod) |
+| panda.sandboxImage | string | `"ethpandaops/panda:sandbox-0.37.0"` | Sandbox container image panda-server spawns for Python execution (must track the panda-server version baked into the overlay image) |
+| panda.storageDriver | string | `"overlay2"` | dockerd storage driver. overlay2 is reliable because dockerd's data-root is a node-local emptyDir (see panda.dockerStorage), not the pod's overlay rootfs — so overlay2 stacks on ext4/xfs instead of overlayfs. Fall back to vfs only for exotic nodes whose kubelet dir is itself overlayfs/NFS. |
 | persistence.accessModes | list | `["ReadWriteOnce"]` | Access modes |
 | persistence.enabled | bool | `true` | Enable a PVC for /opt/data (Hermes state + panda config/creds/storage) |
 | persistence.existingClaim | string | `""` | Use an existing claim instead of creating one |

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -82,7 +82,7 @@ Two images, both built from [`ethpandaops/chat`](https://github.com/ethpandaops/
 
 - `image.repository` (`ethpandaops/hermes-agent-panda`) — the Hermes agent
   with the panda overlay (panda CLI + panda-server + dockerd + entrypoint + skills).
-- `open-webui.image` (`ethpandaops/open-webui-cf`) — Open-WebUI patched to
+- `open-webui.image` (`ethpandaops/chat:open-webui-cf-<ow_tag>`) — Open-WebUI patched to
   forward the Cloudflare Access JWT to the agent (see [Access control](#access-control)).
   Its tag must match the `open-webui` subchart appVersion.
 
@@ -142,8 +142,8 @@ open-webui:
 | open-webui.enabled | bool | `true` | Render the Open-WebUI front end |
 | open-webui.extraEnvVars[0].name | string | `"ENABLE_OLLAMA_API"` |  |
 | open-webui.extraEnvVars[0].value | string | `"false"` |  |
-| open-webui.image.repository | string | `"ethpandaops/open-webui-cf"` |  |
-| open-webui.image.tag | string | `"0.9.5"` |  |
+| open-webui.image.repository | string | `"ethpandaops/chat"` |  |
+| open-webui.image.tag | string | `"open-webui-cf-0.10.2"` |  |
 | open-webui.ingress.annotations | object | `{}` |  |
 | open-webui.ingress.class | string | `"ingress-nginx-public"` |  |
 | open-webui.ingress.enabled | bool | `true` |  |

--- a/charts/panda-chat/README.md
+++ b/charts/panda-chat/README.md
@@ -1,7 +1,7 @@
 
 # panda-chat
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.6.5](https://img.shields.io/badge/AppVersion-2026.6.5-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2026.7.1](https://img.shields.io/badge/AppVersion-2026.7.1-informational?style=flat-square)
 
 AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResearch Hermes agent wired to the `panda` CLI, giving anyone access to devnet analytics (Xatu/Prometheus/Loki/Dora/Ethnode via panda-proxy), account funding (powfaucet) and join-the-devnet helpers.
 
@@ -11,7 +11,7 @@ AI chat for an Ethereum devnet — an Open-WebUI front end backed by a NousResea
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://helm.openwebui.com | open-webui | 14.5.0 |
+| https://helm.openwebui.com | open-webui | 15.2.0 |
 
 ## What this deploys
 
@@ -80,7 +80,7 @@ wires the trusted-header config from a single toggle — see `chat.yaml.j2`.
 
 Two images, both built from [`ethpandaops/chat`](https://github.com/ethpandaops/chat):
 
-- `image.repository` (`ethpandaops/hermes-agent-panda`) — the Hermes agent
+- `image.repository` (`ethpandaops/chat:hermes-agent-panda-*`) — the Hermes agent
   with the panda overlay (panda CLI + panda-server + dockerd + entrypoint + skills).
 - `open-webui.image` (`ethpandaops/chat:open-webui-cf-<ow_tag>`) — Open-WebUI patched to
   forward the Cloudflare Access JWT to the agent (see [Access control](#access-control)).
@@ -125,8 +125,8 @@ open-webui:
 | devnetTools.observability | object | `{}` | Observability tools DEPLOYED for this devnet (name -> URL), e.g. {dora: "...", forky: "...", tracoor: "...", assertoor: "..."}. Declared by the deployment pipeline and injected as DEVNET_TOOL_URLS into the agent's context briefing — the agent never probes or guesses tool URLs. |
 | fullnameOverride | string | `""` | Overrides the chart's computed fullname |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ethpandaops/hermes-agent-panda"` | Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server + dockerd). |
-| image.tag | string | `""` | Image tag. Defaults to the chart appVersion when empty. |
+| image.repository | string | `"ethpandaops/chat"` | Panda-overlay Hermes agent image; CI publishes only docker.io/ethpandaops/chat with a hermes-agent-panda-* tag prefix. |
+| image.tag | string | `"hermes-agent-panda-latest"` | Image tag (mutable convenience default; pin a -<sha> tag in GitOps). |
 | imagePullSecrets | list | `[]` | Image pull secrets for the agent image |
 | langfuse.baseUrl | string | `""` | Langfuse base URL |
 | langfuse.enabled | bool | `false` | Enable Langfuse tracing |

--- a/charts/panda-chat/templates/configmap.yaml
+++ b/charts/panda-chat/templates/configmap.yaml
@@ -18,13 +18,26 @@ data:
       {{- end }}
     agent:
       system_prompt: |
-        {{- .Values.systemPrompt | replace "{{ network }}" .Values.network | nindent 8 }}
+        {{- .Values.systemPrompt | replace "{{ network }}" .Values.network | replace "{{ chainId }}" (.Values.chainId | toString) | nindent 8 }}
     honcho:
       enabled: true
     {{- if .Values.langfuse.enabled }}
     plugins:
       enabled:
         - observability/langfuse
+    {{- end }}
+    {{- if and .Values.telegram.enabled (or .Values.telegram.allowedChats .Values.telegram.groupAllowedChats) }}
+    # Telegram gateway allowlists (the token itself is env: TELEGRAM_BOT_TOKEN,
+    # user allowlist is env: TELEGRAM_ALLOWED_USERS). Chat/group scoping is
+    # yaml-only in Hermes, so it lives here.
+    platforms:
+      telegram:
+        {{- with .Values.telegram.allowedChats }}
+        allowed_chats: {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.telegram.groupAllowedChats }}
+        group_allowed_chats: {{- toYaml . | nindent 10 }}
+        {{- end }}
     {{- end }}
   {{- if .Values.panda.enabled }}
   # panda-server config — seeded to /opt/data/.config/panda/config.yaml. The

--- a/charts/panda-chat/templates/deployment.yaml
+++ b/charts/panda-chat/templates/deployment.yaml
@@ -136,12 +136,15 @@ spec:
             - secretRef:
                 name: {{ include "panda-chat.pandaSecretName" . }}
           # exec probes: panda-server binds 127.0.0.1, which kubelet httpGet
-          # (pod IP) can't reach. ~5 min budget: dockerd + sandbox pull + server.
+          # (pod IP) can't reach. ~20 min budget: a cold start is dockerd +
+          # sandbox image pull + panda-server, and panda-server rebuilds its
+          # EIP semantic index on boot (~8-10 min when the proxy embed cache
+          # is cold) — a tighter budget CrashLoops mid-embed.
           startupProbe:
             exec:
               command: ["sh", "-c", "curl -sf http://127.0.0.1:2480/health"]
             periodSeconds: 5
-            failureThreshold: 60
+            failureThreshold: 240
           livenessProbe:
             exec:
               command: ["sh", "-c", "curl -sf http://127.0.0.1:2480/health"]
@@ -149,11 +152,22 @@ spec:
           resources: {{- toYaml .Values.panda.resources | nindent 12 }}
           volumeMounts:
             - {name: data, mountPath: /opt/data}
+            # dockerd data-root on a node-local emptyDir (kubelet dir = ext4/xfs),
+            # NOT the pod's overlay rootfs. overlay2 refuses to stack its
+            # upperdir on another overlayfs (kernel: DCACHE_OP_REAL upperdir +
+            # FILESYSTEM_MAX_STACK_DEPTH=2 → EINVAL → dockerd CrashLoop); on a
+            # real fs it works natively. Ephemeral: the sandbox image is
+            # re-pulled on cold start (entrypoint does this).
+            - {name: docker-storage, mountPath: /var/lib/docker}
         {{- end }}
       volumes:
         - name: config
           configMap:
             name: {{ include "panda-chat.configMapName" . }}
+        {{- if .Values.panda.enabled }}
+        - name: docker-storage
+          emptyDir: {{- toYaml .Values.panda.dockerStorage | nindent 12 }}
+        {{- end }}
         - name: data
           {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:

--- a/charts/panda-chat/templates/deployment.yaml
+++ b/charts/panda-chat/templates/deployment.yaml
@@ -100,6 +100,21 @@ spec:
             - {name: HERMES_LANGFUSE_BASE_URL, value: {{ .Values.langfuse.baseUrl | quote }}}
             - {name: HERMES_LANGFUSE_ENV, value: {{ .Values.langfuse.env | default .Values.network | quote }}}
             {{- end }}
+            {{- with .Values.devnetTools.observability }}
+            # Deployment-declared tool map ("name=url …") consumed by the
+            # devnet-context briefing — the agent never probes/guesses URLs.
+            {{- $pairs := list }}
+            {{- range $name, $url := . }}
+            {{- $pairs = append $pairs (printf "%s=%s" $name $url) }}
+            {{- end }}
+            - {name: DEVNET_TOOL_URLS, value: {{ join " " $pairs | quote }}}
+            {{- end }}
+            {{- if .Values.telegram.enabled }}
+            # Token arrives via envFrom (hermes Secret); allowlist is plain env.
+            {{- with .Values.telegram.allowedUsers }}
+            - {name: TELEGRAM_ALLOWED_USERS, value: {{ . | quote }}}
+            {{- end }}
+            {{- end }}
           envFrom:
             # Hermes secret only (bearer, LLM key, langfuse) — the panda bot
             # credential lives in its own Secret on the sidecar.

--- a/charts/panda-chat/templates/secret.yaml
+++ b/charts/panda-chat/templates/secret.yaml
@@ -50,6 +50,10 @@ stringData:
   HERMES_LANGFUSE_SECRET_KEY: {{ . | quote }}
   {{- end }}
   {{- end }}
+  {{- if .Values.telegram.enabled }}
+  # Presence of TELEGRAM_BOT_TOKEN is what switches Hermes' telegram adapter on.
+  TELEGRAM_BOT_TOKEN: {{ required "credentials.telegram.botToken is required when telegram.enabled" .Values.credentials.telegram.botToken | quote }}
+  {{- end }}
 {{- if .Values.panda.enabled }}
 ---
 apiVersion: v1

--- a/charts/panda-chat/templates/secret.yaml
+++ b/charts/panda-chat/templates/secret.yaml
@@ -1,21 +1,33 @@
 {{/*
 Two Secrets with a deliberate trust boundary between them:
 
-- <hermes>-secret: API_SERVER_KEY (Hermes bearer, generated once and
-  preserved), <llm.apiKeyEnv> (model key) and HERMES_LANGFUSE_* (tracing
-  keys). envFrom'd ONLY into the unprivileged hermes container.
+- <hermes>-secret: API_SERVER_KEY (Hermes bearer, see below), <llm.apiKeyEnv>
+  (model key) and HERMES_LANGFUSE_* (tracing keys). envFrom'd ONLY into the
+  unprivileged hermes container.
 - <hermes>-panda-secret: PANDA_BOT_USERNAME / PANDA_BOT_TOKEN (the
   Authentik service-account identity panda-server mints client_credentials
   tokens with). envFrom'd ONLY into the panda-server sidecar. Hermes
   executes LLM-driven shell commands, so it must never share an
   environment (or container) with the bot credential.
 */}}
+{{/*
+API_SERVER_KEY (OW <-> Hermes bearer) resolution, in priority order:
+  1. credentials.apiServerKey — an explicit, STABLE value. GitOps supplies it
+     from sops; this is the only source that survives ArgoCD, whose client-side
+     `helm template` has no cluster connection (see 2).
+  2. lookup-preserve of the existing in-cluster Secret. Works under a direct
+     `helm upgrade`, but is a NO-OP under ArgoCD — so it must not be the only
+     source, or every re-render mints a fresh bearer and OW/Hermes drift apart.
+  3. randAlphaNum — first-install fallback for a bare `helm install`.
+*/}}
 {{- $secretName := include "panda-chat.secretName" . -}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
-{{- $bearer := "" -}}
-{{- if and $existing $existing.data -}}
-  {{- with index $existing.data "API_SERVER_KEY" -}}
-    {{- $bearer = . | b64dec -}}
+{{- $bearer := .Values.credentials.apiServerKey -}}
+{{- if not $bearer -}}
+  {{- $existing := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+  {{- if and $existing $existing.data -}}
+    {{- with index $existing.data "API_SERVER_KEY" -}}
+      {{- $bearer = . | b64dec -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 {{- if not $bearer -}}{{- $bearer = randAlphaNum 40 -}}{{- end -}}

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -12,10 +12,14 @@ network: ""
 chainId: ""
 
 image:
-  # -- Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server + dockerd).
-  repository: ethpandaops/hermes-agent-panda
-  # -- Image tag. Defaults to the chart appVersion when empty.
-  tag: ""
+  # -- Panda-overlay Hermes agent image (Hermes + panda CLI + panda-server +
+  # dockerd). CI publishes ONLY docker.io/ethpandaops/chat with a
+  # hermes-agent-panda-* prefix (the standalone ethpandaops/hermes-agent-panda
+  # repo is a stale pre-consolidation push). Pin the immutable
+  # hermes-agent-panda-<base>-<sha> tag per deployment.
+  repository: ethpandaops/chat
+  # -- Image tag (mutable convenience default; pin a -<sha> tag in GitOps).
+  tag: "hermes-agent-panda-latest"
   # -- Image pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -37,11 +37,12 @@ llm:
 
 # -- System prompt for the agent. `{{ network }}` is substituted at render time.
 systemPrompt: |
-  You are the EthPandaOps assistant for the Ethereum devnet "{{ network }}".
-  Help users understand devnet state and use the EthPandaOps tooling:
-  query live data with the `panda` skill, fund accounts with the `faucet`
-  skill, and join the network with the `join-devnet` skill. Be concise and
-  always scope data queries to this devnet.
+  You are the EthPandaOps assistant for the Ethereum devnet "{{ network }}" (chain id {{ chainId }}), scoped to it alone.
+  Skills: `panda` (chain data, metrics, logs, live nodes), `faucet` (fund accounts), `join-devnet` (join the network), `devnet-tools` (tooling map).
+  Start every devnet question by reading /opt/data/devnet-context.md — it holds this devnet's fork schedule, tool URLs, and node inventory; regenerate with `/opt/panda/devnet-context.sh --refresh` if stale.
+  Discover before querying (the `panda` skill shows how); never invent APIs, tables, node names, or URLs.
+  Report exactly what the tools return — never fabricate; if data is missing or sources disagree, say so.
+  Lead with the numbers, in plain English. Be concise — answers are read on phones and in Telegram.
 
 # Panda integration. When enabled the pod gains a separate privileged
 # "panda-server" sidecar container (panda-server + dockerd) holding the bot
@@ -104,6 +105,26 @@ devnetTools:
     rpcUrl: ""
     # -- Block explorer URL
     explorerUrl: ""
+  # -- Observability tools DEPLOYED for this devnet (name -> URL), e.g.
+  # {dora: "https://dora.<net>...", forky: "...", tracoor: "...", assertoor: "..."}.
+  # Declared by the deployment pipeline (the ansible role knows what it
+  # deployed) and injected as DEVNET_TOOL_URLS into the agent's context
+  # briefing — the agent never probes or guesses tool URLs.
+  observability: {}
+
+# Telegram gateway for the SAME Hermes agent (shared team bot per devnet).
+# Hermes' telegram adapter enables itself when TELEGRAM_BOT_TOKEN is present
+# (from credentials.telegram.botToken); it long-polls Telegram, so no ingress
+# or webhook is needed and Cloudflare Access stays untouched.
+telegram:
+  # -- Enable the Telegram gateway (requires credentials.telegram.botToken)
+  enabled: false
+  # -- Numeric Telegram user ids allowed to DM the bot (comma-separated string)
+  allowedUsers: ""
+  # -- Telegram chat ids allowed as DM chats (list, optional)
+  allowedChats: []
+  # -- Telegram group chat ids the bot may serve (list, optional)
+  groupAllowedChats: []
 
 # Credentials. Injected via vals `<path:...>` on devnets; set directly for standalone use.
 credentials:
@@ -127,6 +148,11 @@ credentials:
     publicKey: ""
     # -- Langfuse secret key (sk-lf-...)
     secretKey: ""
+  telegram:
+    # -- BotFather bot token (`<id>:<secret>`). Required when `telegram.enabled`.
+    # Goes into the hermes Secret as TELEGRAM_BOT_TOKEN, which is what switches
+    # the gateway's telegram adapter on.
+    botToken: ""
 
 # -- Resources for the hermes container (panda-server sidecar sized separately under `panda.resources`)
 resources:

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -58,9 +58,17 @@ panda:
   # -- OAuth client id at the proxy
   clientId: "panda-proxy"
   # -- Sandbox container image panda-server spawns for Python execution
-  sandboxImage: "ethpandaops/panda:sandbox-v0.31.0"
-  # -- dockerd storage driver (overlay2; set to vfs if overlayfs is unavailable in-pod)
+  # (must track the panda-server version baked into the overlay image)
+  sandboxImage: "ethpandaops/panda:sandbox-0.37.0"
+  # -- dockerd storage driver. overlay2 is reliable because dockerd's data-root
+  # is a node-local emptyDir (see panda.dockerStorage), not the pod's overlay
+  # rootfs — so overlay2 stacks on ext4/xfs instead of overlayfs. Fall back to
+  # vfs only for exotic nodes whose kubelet dir is itself overlayfs/NFS.
   storageDriver: overlay2
+  # -- emptyDir spec for dockerd's /var/lib/docker (the sandbox layer cache).
+  # Node-local so overlay2 works; ephemeral (re-pulled on cold start). Cap it
+  # with `sizeLimit: 10Gi`, or set `medium: ""` explicitly; {} = node default.
+  dockerStorage: {}
   # -- Resources for the panda-server sidecar (panda-server + dockerd + sandboxes)
   resources:
     requests:

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -205,11 +205,11 @@ open-webui:
   replicaCount: 1
   # CF-Access-aware Open-WebUI: forwards Cf-Access-Jwt-Assertion to the agent so
   # Hermes sees the individual user (per-user auth + Langfuse attribution). The tag
-  # MUST match this subchart's appVersion (open-webui 14.5.0 -> 0.9.5); bump together.
+  # MUST match this subchart's appVersion (open-webui 15.2.0 -> 0.10.2); bump together.
   # Built from github.com/ethpandaops/chat (images/open-webui-cf).
   image:
     repository: ethpandaops/open-webui-cf
-    tag: "0.9.5"
+    tag: "0.10.2"
   # Route models through Hermes, not the bundled Ollama / Pipelines.
   ollama:
     enabled: false

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -204,12 +204,16 @@ open-webui:
   enabled: true
   replicaCount: 1
   # CF-Access-aware Open-WebUI: forwards Cf-Access-Jwt-Assertion to the agent so
-  # Hermes sees the individual user (per-user auth + Langfuse attribution). The tag
-  # MUST match this subchart's appVersion (open-webui 15.2.0 -> 0.10.2); bump together.
-  # Built from github.com/ethpandaops/chat (images/open-webui-cf).
+  # Hermes sees the individual user (per-user auth + Langfuse attribution). The OW
+  # version in the tag MUST match this subchart's appVersion (open-webui 15.2.0 ->
+  # 0.10.2); bump together. Built from github.com/ethpandaops/chat
+  # (images/open-webui-cf); CI publishes ONLY docker.io/ethpandaops/chat with an
+  # open-webui-cf-<ow_tag> prefix (the standalone ethpandaops/open-webui-cf repo
+  # was a one-off manual push and does not receive new tags). Pin the immutable
+  # open-webui-cf-<ow_tag>-<sha> tag per deployment if you need reproducibility.
   image:
-    repository: ethpandaops/open-webui-cf
-    tag: "0.10.2"
+    repository: ethpandaops/chat
+    tag: "open-webui-cf-0.10.2"
   # Route models through Hermes, not the bundled Ollama / Pipelines.
   ollama:
     enabled: false

--- a/charts/panda-chat/values.yaml
+++ b/charts/panda-chat/values.yaml
@@ -99,6 +99,11 @@ devnetTools:
 
 # Credentials. Injected via vals `<path:...>` on devnets; set directly for standalone use.
 credentials:
+  # -- Stable OW<->Hermes bearer (`API_SERVER_KEY`). Leave empty for a bare
+  # `helm install` (auto-generated + preserved). Under GitOps/ArgoCD you MUST
+  # set this to a stable value (sops) — `helm template` can't preserve a
+  # generated one, so an empty value drifts OW and Hermes apart on re-render.
+  apiServerKey: ""
   # -- The LLM API key value (materialized into the Secret under `llm.apiKeyEnv`)
   llmApiKey: ""
   panda:


### PR DESCRIPTION
## What

panda-chat **v0.3.1**: keeps master's Docker-in-Docker sandbox (`backend: docker`, privileged panda-server sidecar + in-pod dockerd) and adds the **stable `API_SERVER_KEY` bearer** fix so the OW↔Hermes bearer survives ArgoCD instead of drifting on every render (cherry-picked `bc92538`).

Deliberately **not** the `direct` backend (that lived only in the unmerged panda PR #214; panda master/releases ship only `docker`/`gvisor`).

## Reliable overlay2 (not vfs)

The overlay2 CrashLoop on devnet nodes wasn't inherent — dockerd's default `--data-root=/var/lib/docker` sat on the **pod's overlay rootfs**, and the kernel forbids stacking an overlay `upperdir` on another overlayfs (`ovl_mount_dir_check` rejects a `DCACHE_OP_REAL` upperdir → `EINVAL`; `FILESYSTEM_MAX_STACK_DEPTH=2`). Fix: mount a dedicated **node-local emptyDir** at `/var/lib/docker` (`panda.dockerStorage`) so overlay2 stacks on ext4/xfs with real CoW. `storageDriver` default is now `overlay2`; `vfs` stays selectable for exotic nodes (overlayfs/NFS kubelet dir).

## Changes
- `values`: `sandboxImage` → `sandbox-0.37.0`; add `panda.dockerStorage` (emptyDir spec); `storageDriver: overlay2`.
- `deployment`: mount `docker-storage` emptyDir at `/var/lib/docker`; startupProbe 5m → 20m (cold start = dockerd + sandbox pull + EIP embed).
- `secret`/`values`/`README`: stable `credentials.apiServerKey` bearer.

Pairs with the chat image PR (ethpandaops/chat#3) built from panda `0.37.0`.