### PR TITLE
feat: support existing Secret for the engine JWT

### DIFF
--- a/charts/besu/Chart.yaml
+++ b/charts/besu/Chart.yaml
@@ -8,7 +8,7 @@ icon: https://launchpad.ethereum.org/static/media/hyperledger-besu-circle.b96368
 sources:
   - https://github.com/besu-eth/besu
 type: application
-version: 1.1.3
+version: 1.1.4
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/besu/README.md
+++ b/charts/besu/README.md
@@ -1,7 +1,7 @@
 
 # besu
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An Ethereum execution layer client designed to be enterprise-friendly for both public and private, permissioned network use cases. Besu is written in Java and released under the Apache 2.0 Licence.
 
@@ -29,6 +29,7 @@ An Ethereum execution layer client designed to be enterprise-friendly for both p
 | devnet.urls | object | `{"elBootnode":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt","genesisJson":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/besu.json"}` | URLs for devnet configuration files |
 | devnet.urls.elBootnode | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt"` | Execution layer bootnode URL |
 | devnet.urls.genesisJson | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/besu.json"` | Genesis JSON URL for execution layer (using besu-specific file) |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the besu container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
@@ -107,6 +108,14 @@ An Ethereum execution layer client designed to be enterprise-friendly for both p
 | wsPort | int | `8546` | WS Port |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Connecting to the holesky test network
 

--- a/charts/besu/README.md.gotmpl
+++ b/charts/besu/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Connecting to the holesky test network
 
 ```yaml

--- a/charts/besu/templates/secret.yaml
+++ b/charts/besu/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/besu/templates/statefulset.yaml
+++ b/charts/besu/templates/statefulset.yaml
@@ -171,7 +171,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "besu.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "besu.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/besu/values.yaml
+++ b/charts/besu/values.yaml
@@ -22,6 +22,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Devnet configuration
 devnet:
   # -- Enable devnet mode

--- a/charts/eleel/Chart.yaml
+++ b/charts/eleel/Chart.yaml
@@ -3,7 +3,7 @@ name: eleel
 description: A multiplexer for Ethereum execution clients
 home: https://github.com/sigp/eleel
 type: application
-version: 0.1.6
+version: 0.1.7
 maintainers:
   - name: samcm
     email: sam.calder-mason@ethereum.org

--- a/charts/eleel/README.md
+++ b/charts/eleel/README.md
@@ -1,7 +1,7 @@
 
 # eleel
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A multiplexer for Ethereum execution clients
 
@@ -20,6 +20,7 @@ A multiplexer for Ethereum execution clients
 | customArgs | list | `[]` | Custom args for the eleel container |
 | customCommand | list | `[]` | Command replacement for the eleel container |
 | eeJWTSecret | string | `""` | Execution Engine JWT secret |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWTs instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the keys `execution.jwt`, `controller.jwt` (JWT secrets as hex strings) and `client-secrets.toml` (client secrets in eleel's TOML format). When set, `eeJWTSecret`, `controllerJWTSecret` and `clientJWTSecrets` are ignored. |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
 | extraPodPorts | list | `[]` | Extra Pod ports |
@@ -56,3 +57,13 @@ A multiplexer for Ethereum execution clients
 | terminationGracePeriodSeconds | int | `30` | How long to wait until the pod is forcefully terminated |
 | tolerations | list | `[]` | Tolerations for pods |
 | topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pods |
+
+# Examples
+
+## Using an existing JWT Secret
+
+If the JWT secrets are managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference an existing Secret instead of letting the chart create one. The Secret must contain the keys `execution.jwt`, `controller.jwt` (JWT secrets as hex strings) and `client-secrets.toml` (client secrets in eleel's TOML format). Note that `execution.jwt` must match the JWT secret of the upstream execution client (its `jwt.hex`):
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```

--- a/charts/eleel/README.md.gotmpl
+++ b/charts/eleel/README.md.gotmpl
@@ -13,3 +13,13 @@
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}
+
+# Examples
+
+## Using an existing JWT Secret
+
+If the JWT secrets are managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference an existing Secret instead of letting the chart create one. The Secret must contain the keys `execution.jwt`, `controller.jwt` (JWT secrets as hex strings) and `client-secrets.toml` (client secrets in eleel's TOML format). Note that `execution.jwt` must match the JWT secret of the upstream execution client (its `jwt.hex`):
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```

--- a/charts/eleel/templates/deployment.yaml
+++ b/charts/eleel/templates/deployment.yaml
@@ -111,4 +111,4 @@ spec:
       {{- end }}
         - name: jwt
           secret:
-            secretName: {{ include "eleel.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "eleel.fullname" .)) }}

--- a/charts/eleel/templates/secret.yaml
+++ b/charts/eleel/templates/secret.yaml
@@ -8,13 +8,15 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "eleel.fullname" . }}-jwt
-type: Opaque  
+type: Opaque
 data:
   execution.jwt: {{ .Values.eeJWTSecret | b64enc }}
   controller.jwt: {{ .Values.controllerJWTSecret | b64enc }}
   client-secrets.toml: {{ include "eleel.clientJWTSecretsToToml" . | b64enc }}
+{{- end }}

--- a/charts/eleel/values.yaml
+++ b/charts/eleel/values.yaml
@@ -34,6 +34,13 @@ clientJWTSecrets: {}
   # node1: c259fb249f7fa1882b1d4150ace73c1023aba4f6267b29a871ad5c9adc7a543a
   # node2: fb6073f77160f9a7ce11190d3612e841daea2e7319a59e1d82a8804e9fa193ee
 
+# -- Use an existing Secret for the JWTs instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the keys
+# `execution.jwt`, `controller.jwt` (JWT secrets as hex strings) and
+# `client-secrets.toml` (client secrets in eleel's TOML format). When set,
+# `eeJWTSecret`, `controllerJWTSecret` and `clientJWTSecrets` are ignored.
+existingJwtSecret: ""
+
 ingress:
   # -- Ingress resource for the HTTP API
   enabled: false

--- a/charts/erigon/Chart.yaml
+++ b/charts/erigon/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://pbs.twimg.com/profile_images/1420080204148576274/-4OFIs2x_400x400.
 sources:
   - https://github.com/ledgerwatch/erigon
 type: application
-version: 2.0.1
+version: 2.0.2
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/erigon/README.md
+++ b/charts/erigon/README.md
@@ -1,7 +1,7 @@
 
 # erigon
 
-![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.2](https://img.shields.io/badge/Version-2.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented toward speed and disk‐space efficiency. Erigon is a completely re-architected implementation of Ethereum, currently written in Go but with implementations in other languages planned. Erigon's goal is to provide a faster, more modular, and more optimized implementation of Ethereum.
 
@@ -30,6 +30,7 @@ Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented
 | devnet.urls | object | `{"elBootnode":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt","genesisJson":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"}` | URLs for devnet configuration files |
 | devnet.urls.elBootnode | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt"` | Execution layer bootnode URL |
 | devnet.urls.genesisJson | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"` | Genesis JSON URL for execution layer |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the erigon container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables for erigon container |
@@ -107,6 +108,14 @@ Erigon, formerly known as Turbo‐Geth, is a fork of Go Ethereum (geth) oriented
 | updateStrategy.type | string | `"RollingUpdate"` | Update strategy type |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Connecting to the holesky test network
 

--- a/charts/erigon/README.md.gotmpl
+++ b/charts/erigon/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Connecting to the holesky test network
 
 ```yaml

--- a/charts/erigon/templates/secret.yaml
+++ b/charts/erigon/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/erigon/templates/statefulset.yaml
+++ b/charts/erigon/templates/statefulset.yaml
@@ -167,7 +167,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "erigon.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "erigon.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/erigon/values.yaml
+++ b/charts/erigon/values.yaml
@@ -22,6 +22,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Enable Caplin (Erigon's built-in consensus layer client). When false, --externalcl flag is added.
 caplin:
   enabled: false

--- a/charts/ethereumjs/Chart.yaml
+++ b/charts/ethereumjs/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://user-images.githubusercontent.com/47108/78779352-d0839500-796a-11e
 sources:
   - https://github.com/ethereumjs/ethereumjs-monorepo
 type: application
-version: 0.1.1
+version: 0.1.2
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/ethereumjs/README.md
+++ b/charts/ethereumjs/README.md
@@ -1,7 +1,7 @@
 
 # ethereumjs
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 The EthereumJS Client is an Ethereum Execution Client (similar to go-ethereum or Nethermind) written in TypeScript/JavaScript, the non-Smart-Contract language Ethereum dApp developers are most familiar with. It is targeted to be a client for research and development and not meant to be used in production on mainnet for the foreseeable future (out of resource and security considerations).
 
@@ -30,6 +30,7 @@ The EthereumJS Client is an Ethereum Execution Client (similar to go-ethereum or
 | devnet.urls | object | `{"elBootnode":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt","genesisJson":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"}` | URLs for devnet configuration files |
 | devnet.urls.elBootnode | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt"` | Execution layer bootnode URL |
 | devnet.urls.genesisJson | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"` | Genesis JSON URL for execution layer |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the ethereumjs container |
 | extraContainerPorts | list | `[]` | Additional ports for the main container |
 | extraContainers | list | `[]` | Additional containers |
@@ -109,6 +110,14 @@ The EthereumJS Client is an Ethereum Execution Client (similar to go-ethereum or
 | wsPort | int | `8546` | WS Port |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Connecting to the holesky test network
 

--- a/charts/ethereumjs/README.md.gotmpl
+++ b/charts/ethereumjs/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Connecting to the holesky test network
 
 ```yaml

--- a/charts/ethereumjs/templates/secret.yaml
+++ b/charts/ethereumjs/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/ethereumjs/templates/statefulset.yaml
+++ b/charts/ethereumjs/templates/statefulset.yaml
@@ -172,7 +172,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "ethereumjs.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "ethereumjs.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/ethereumjs/values.yaml
+++ b/charts/ethereumjs/values.yaml
@@ -22,6 +22,11 @@ extraArgs: []
 # -- JWT secret is attached as a secret object. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Devnet configuration
 devnet:
   # -- Enable devnet mode

--- a/charts/ethrex/Chart.yaml
+++ b/charts/ethrex/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://avatars.githubusercontent.com/u/6535196
 sources:
   - https://github.com/lambdaclass/ethrex
 type: application
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: mattevans
     email: matt.evans@ethereum.org

--- a/charts/ethrex/README.md
+++ b/charts/ethrex/README.md
@@ -1,7 +1,7 @@
 
 # ethrex
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Ethrex is an Ethereum execution client developed by Lambda Class. It is written in Rust and designed to be modular, efficient, and fully compatible with Ethereum's Engine API for connecting to consensus layer clients.
 
@@ -31,6 +31,7 @@ Ethrex is an Ethereum execution client developed by Lambda Class. It is written 
 | devnet.urls.elBootnode | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt"` | Execution layer bootnode URL |
 | devnet.urls.genesisJson | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"` | Genesis JSON URL for execution layer |
 | dnsPolicy | string | `""` | DNS policy for pods When hostNetwork is true, this should be set to ClusterFirstWithHostNet |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the ethrex container |
 | extraContainerPorts | list | `[]` | Additional ports for the main container |
 | extraContainers | list | `[]` | Additional containers |
@@ -112,6 +113,14 @@ Ethrex is an Ethereum execution client developed by Lambda Class. It is written 
 | wsPort | int | `8546` | WS Port |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Connecting to the holesky test network
 

--- a/charts/ethrex/README.md.gotmpl
+++ b/charts/ethrex/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Connecting to the holesky test network
 
 ```yaml

--- a/charts/ethrex/templates/secret.yaml
+++ b/charts/ethrex/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/ethrex/templates/statefulset.yaml
+++ b/charts/ethrex/templates/statefulset.yaml
@@ -200,7 +200,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "ethrex.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "ethrex.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/ethrex/values.yaml
+++ b/charts/ethrex/values.yaml
@@ -25,6 +25,11 @@ extraArgs: []
 # -- JWT secret is attached as a secret object. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Devnet configuration
 devnet:
   # -- Enable devnet mode

--- a/charts/geth/Chart.yaml
+++ b/charts/geth/Chart.yaml
@@ -9,7 +9,7 @@ icon: https://launchpad.ethereum.org/static/media/gethereum-mascot-circle.75cbd3
 sources:
   - https://github.com/ethereum/go-ethereum
 type: application
-version: 1.1.3
+version: 1.1.4
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/geth/README.md
+++ b/charts/geth/README.md
@@ -1,7 +1,7 @@
 
 # geth
 
-![Version: 1.1.3](https://img.shields.io/badge/Version-1.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Go Ethereum (Geth for short) is one of the original implementations of the Ethereum protocol. Currently, it is the most widespread client with the biggest user base and variety of tooling for users and developers. It is written in Go, fully open source and licensed under the GNU LGPL v3
 
@@ -30,6 +30,7 @@ Go Ethereum (Geth for short) is one of the original implementations of the Ether
 | devnet.urls | object | `{"elBootnode":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt","genesisJson":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"}` | URLs for devnet configuration files |
 | devnet.urls.elBootnode | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt"` | Execution layer bootnode URL |
 | devnet.urls.genesisJson | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"` | Genesis JSON URL for execution layer |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the geth container |
 | extraContainerPorts | list | `[]` | Additional ports for the main container |
 | extraContainers | list | `[]` | Additional containers |
@@ -109,6 +110,14 @@ Go Ethereum (Geth for short) is one of the original implementations of the Ether
 | wsPort | int | `8545` | WS Port |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Connecting to the holesky test network
 

--- a/charts/geth/README.md.gotmpl
+++ b/charts/geth/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Connecting to the holesky test network
 
 ```yaml

--- a/charts/geth/templates/secret.yaml
+++ b/charts/geth/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/geth/templates/statefulset.yaml
+++ b/charts/geth/templates/statefulset.yaml
@@ -178,7 +178,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "geth.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "geth.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/geth/values.yaml
+++ b/charts/geth/values.yaml
@@ -28,6 +28,11 @@ config: |
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Devnet configuration
 devnet:
   # -- Enable devnet mode

--- a/charts/grandine/Chart.yaml
+++ b/charts/grandine/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://github.com/sifraitech/grandine/blob/master/gui.png
 sources:
   - https://github.com/sifraitech/grandine
 type: application
-version: 0.2.1
+version: 0.2.2
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/grandine/README.md
+++ b/charts/grandine/README.md
@@ -1,7 +1,7 @@
 
 # grandine
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A currently closed source, but hopefully soon to be open-source Ethereum Consensus layer client, written in Rust.
 
@@ -32,6 +32,7 @@ A currently closed source, but hopefully soon to be open-source Ethereum Consens
 | devnet.urls.configYaml | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/config.yaml"` | Chain config YAML URL |
 | devnet.urls.depositContractBlock | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/deposit_contract_block.txt"` | Deposit contract block number URL |
 | devnet.urls.genesisSsz | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.ssz"` | Genesis state SSZ URL |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the grandine container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
@@ -106,6 +107,14 @@ A currently closed source, but hopefully soon to be open-source Ethereum Consens
 | updateStrategy.type | string | `"RollingUpdate"` | Update strategy type |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 

--- a/charts/grandine/README.md.gotmpl
+++ b/charts/grandine/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 
 ```yaml

--- a/charts/grandine/templates/secret.yaml
+++ b/charts/grandine/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/grandine/templates/statefulset.yaml
+++ b/charts/grandine/templates/statefulset.yaml
@@ -163,7 +163,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "grandine.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "grandine.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/grandine/values.yaml
+++ b/charts/grandine/values.yaml
@@ -24,6 +24,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Checkpoint Sync
 checkpointSync:
   enabled: false

--- a/charts/lighthouse/Chart.yaml
+++ b/charts/lighthouse/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/lighthouse-circle.e0b82d14.png
 sources:
   - https://github.com/sigp/lighthouse
 type: application
-version: 1.1.8
+version: 1.1.9
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/lighthouse/README.md
+++ b/charts/lighthouse/README.md
@@ -1,7 +1,7 @@
 
 # lighthouse
 
-![Version: 1.1.8](https://img.shields.io/badge/Version-1.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.9](https://img.shields.io/badge/Version-1.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum 2.0 client, written in Rust
 
@@ -34,6 +34,7 @@ An open-source Ethereum 2.0 client, written in Rust
 | devnet.urls.configYaml | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/config.yaml"` | Chain config YAML URL |
 | devnet.urls.depositContractBlock | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/deposit_contract_block.txt"` | Deposit contract block number URL |
 | devnet.urls.genesisSsz | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.ssz"` | Genesis state SSZ URL |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the lighthouse container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
@@ -114,6 +115,14 @@ An open-source Ethereum 2.0 client, written in Rust
 | validatorReadinessProbe | object | See `values.yaml` | Validator Readiness probe |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 

--- a/charts/lighthouse/README.md.gotmpl
+++ b/charts/lighthouse/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 
 ```yaml

--- a/charts/lighthouse/templates/secret.yaml
+++ b/charts/lighthouse/templates/secret.yaml
@@ -8,11 +8,13 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "lighthouse.fullname" . }}-jwt
-type: Opaque  
+type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/lighthouse/templates/statefulset.yaml
+++ b/charts/lighthouse/templates/statefulset.yaml
@@ -176,7 +176,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "lighthouse.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "lighthouse.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/lighthouse/values.yaml
+++ b/charts/lighthouse/values.yaml
@@ -33,6 +33,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Checkpoint Sync
 checkpointSync:
   enabled: false

--- a/charts/lodestar/Chart.yaml
+++ b/charts/lodestar/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://raw.githubusercontent.com/ChainSafe/lodestar/master/assets/lodesta
 sources:
   - https://github.com/ChainSafe/lodestar
 type: application
-version: 1.2.1
+version: 1.2.2
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/lodestar/README.md
+++ b/charts/lodestar/README.md
@@ -1,7 +1,7 @@
 
 # lodestar
 
-![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.2](https://img.shields.io/badge/Version-1.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Lodestar is a open-source TypeScript implementation of the Ethereum consensus engine.
 
@@ -33,6 +33,7 @@ Lodestar is a open-source TypeScript implementation of the Ethereum consensus en
 | devnet.urls.configYaml | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/config.yaml"` | Chain config YAML URL |
 | devnet.urls.depositContractBlock | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/deposit_contract_block.txt"` | Deposit contract block number URL |
 | devnet.urls.genesisSsz | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.ssz"` | Genesis state SSZ URL |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the lodestar container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
@@ -110,6 +111,14 @@ Lodestar is a open-source TypeScript implementation of the Ethereum consensus en
 | validatorReadinessProbe | object | See `values.yaml` | Validator Readiness probe |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 

--- a/charts/lodestar/README.md.gotmpl
+++ b/charts/lodestar/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 
 ```yaml

--- a/charts/lodestar/templates/secret.yaml
+++ b/charts/lodestar/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/lodestar/templates/statefulset.yaml
+++ b/charts/lodestar/templates/statefulset.yaml
@@ -177,7 +177,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "lodestar.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "lodestar.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/lodestar/values.yaml
+++ b/charts/lodestar/values.yaml
@@ -32,6 +32,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Checkpoint Sync
 checkpointSync:
   enabled: false

--- a/charts/nethermind/Chart.yaml
+++ b/charts/nethermind/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://launchpad.ethereum.org/static/media/nethermind-circle.fbbf1a32.png
 sources:
   - https://github.com/NethermindEth/nethermind
 type: application
-version: 1.1.1
+version: 1.1.2
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/nethermind/README.md
+++ b/charts/nethermind/README.md
@@ -1,7 +1,7 @@
 
 # nethermind
 
-![Version: 1.1.1](https://img.shields.io/badge/Version-1.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Nethermind is an Ethereum execution layer implementation created with the C# .NET tech stack, running on all major platforms including ARM.
 
@@ -29,6 +29,7 @@ Nethermind is an Ethereum execution layer implementation created with the C# .NE
 | devnet.urls | object | `{"elBootnode":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt","genesisJson":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/chainspec.json"}` | URLs for devnet configuration files |
 | devnet.urls.elBootnode | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt"` | Execution layer bootnode URL |
 | devnet.urls.genesisJson | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/chainspec.json"` | ChainSpec JSON URL for execution layer (Nethermind format) |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the nethermind container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
@@ -107,6 +108,14 @@ Nethermind is an Ethereum execution layer implementation created with the C# .NE
 | wsPort | int | `8545` | WS Port |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Connecting to the holesky test network
 

--- a/charts/nethermind/README.md.gotmpl
+++ b/charts/nethermind/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Connecting to the holesky test network
 
 ```yaml

--- a/charts/nethermind/templates/secret.yaml
+++ b/charts/nethermind/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/nethermind/templates/statefulset.yaml
+++ b/charts/nethermind/templates/statefulset.yaml
@@ -180,7 +180,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "nethermind.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "nethermind.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/nethermind/values.yaml
+++ b/charts/nethermind/values.yaml
@@ -22,6 +22,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Devnet configuration
 devnet:
   # -- Enable devnet mode

--- a/charts/nimbus/Chart.yaml
+++ b/charts/nimbus/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/nimbus-circle.2752d77b.png
 sources:
   - https://github.com/status-im/nimbus-eth2
 type: application
-version: 1.2.0
+version: 1.2.1
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/nimbus/README.md
+++ b/charts/nimbus/README.md
@@ -1,7 +1,7 @@
 
 # nimbus
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum consensus layer client, written in Nim
 
@@ -33,6 +33,7 @@ An open-source Ethereum consensus layer client, written in Nim
 | devnet.urls.configYaml | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/config.yaml"` | Chain config YAML URL |
 | devnet.urls.depositContractBlock | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/deposit_contract_block.txt"` | Deposit contract block number URL |
 | devnet.urls.genesisSsz | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.ssz"` | Genesis state SSZ URL |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the nimbus container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
@@ -110,6 +111,14 @@ An open-source Ethereum consensus layer client, written in Nim
 | updateStrategy.type | string | `"RollingUpdate"` | Update strategy type |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 

--- a/charts/nimbus/README.md.gotmpl
+++ b/charts/nimbus/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 
 ```yaml

--- a/charts/nimbus/templates/secret.yaml
+++ b/charts/nimbus/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/nimbus/templates/statefulset.yaml
+++ b/charts/nimbus/templates/statefulset.yaml
@@ -160,7 +160,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "nimbus.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "nimbus.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/nimbus/values.yaml
+++ b/charts/nimbus/values.yaml
@@ -29,6 +29,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Checkpoint Sync
 checkpointSync:
   enabled: false

--- a/charts/prysm/Chart.yaml
+++ b/charts/prysm/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/prysmatic-labs-circle.96c803fe
 sources:
   - https://github.com/prysmaticlabs/prysm
 type: application
-version: 1.2.3
+version: 1.2.4
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/prysm/README.md
+++ b/charts/prysm/README.md
@@ -1,7 +1,7 @@
 
 # prysm
 
-![Version: 1.2.3](https://img.shields.io/badge/Version-1.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.4](https://img.shields.io/badge/Version-1.2.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum 2.0 client, written in Go
 
@@ -33,6 +33,7 @@ An open-source Ethereum 2.0 client, written in Go
 | devnet.urls.configYaml | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/config.yaml"` | Chain config YAML URL |
 | devnet.urls.depositContractBlock | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/deposit_contract_block.txt"` | Deposit contract block number URL |
 | devnet.urls.genesisSsz | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.ssz"` | Genesis state SSZ URL |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the prysm container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
@@ -111,6 +112,14 @@ An open-source Ethereum 2.0 client, written in Go
 | validatorReadinessProbe | object | See `values.yaml` | Validator Readiness probe |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 

--- a/charts/prysm/README.md.gotmpl
+++ b/charts/prysm/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 
 ```yaml

--- a/charts/prysm/templates/secret.yaml
+++ b/charts/prysm/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/prysm/templates/statefulset.yaml
+++ b/charts/prysm/templates/statefulset.yaml
@@ -177,7 +177,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "prysm.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "prysm.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/prysm/values.yaml
+++ b/charts/prysm/values.yaml
@@ -40,6 +40,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Checkpoint Sync
 checkpointSync:
   enabled: false

--- a/charts/reth/Chart.yaml
+++ b/charts/reth/Chart.yaml
@@ -7,7 +7,7 @@ icon: https://github.com/paradigmxyz/reth/raw/main/assets/reth.jpg
 sources:
   - https://github.com/paradigmxyz/reth/
 type: application
-version: 0.1.8
+version: 0.1.9
 maintainers:
   - name: barnabasbusa
     email: busa.barnabas@gmail.com

--- a/charts/reth/README.md
+++ b/charts/reth/README.md
@@ -1,7 +1,7 @@
 
 # reth
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implementation that is focused on being user-friendly, highly modular, as well as being fast and efficient. Reth is an Execution Layer (EL) and is compatible with all Ethereum Consensus Layer (CL) implementations that support the Engine API. It is originally built and driven forward by Paradigm, and is licensed under the Apache and MIT licenses.
 
@@ -30,6 +30,7 @@ Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implem
 | devnet.urls | object | `{"elBootnode":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt","genesisJson":"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"}` | URLs for devnet configuration files |
 | devnet.urls.elBootnode | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/enodes.txt"` | Execution layer bootnode URL |
 | devnet.urls.genesisJson | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.json"` | Genesis JSON URL for execution layer |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the reth container |
 | extraContainerPorts | list | `[]` | Additional ports for the main container |
 | extraContainers | list | `[]` | Additional containers |
@@ -115,6 +116,14 @@ Reth (short for Rust Ethereum, pronunciation) is a new Ethereum full node implem
 | wsPort | int | `8546` | WS Port |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Connecting to the holesky test network
 

--- a/charts/reth/README.md.gotmpl
+++ b/charts/reth/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Connecting to the holesky test network
 
 ```yaml

--- a/charts/reth/templates/secret.yaml
+++ b/charts/reth/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/reth/templates/statefulset.yaml
+++ b/charts/reth/templates/statefulset.yaml
@@ -176,7 +176,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "reth.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "reth.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/reth/values.yaml
+++ b/charts/reth/values.yaml
@@ -26,6 +26,11 @@ extraArgs: []
 # -- JWT secret is attached as a secret object. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Devnet configuration
 devnet:
   # -- Enable devnet mode

--- a/charts/teku/Chart.yaml
+++ b/charts/teku/Chart.yaml
@@ -6,7 +6,7 @@ icon: https://launchpad.ethereum.org/static/media/pegasys-teku-circle.4147bb69.p
 sources:
   - https://github.com/Consensys/teku/
 type: application
-version: 1.2.0
+version: 1.2.1
 maintainers:
   - name: skylenet
     email: rafael@skyle.net

--- a/charts/teku/README.md
+++ b/charts/teku/README.md
@@ -1,7 +1,7 @@
 
 # teku
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 An open-source Ethereum 2.0 client, written in Java
 
@@ -34,6 +34,7 @@ An open-source Ethereum 2.0 client, written in Java
 | devnet.urls.depositContractAddress | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/deposit_contract.txt"` | Deposit contract address URL |
 | devnet.urls.depositContractBlock | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/deposit_contract_block.txt"` | Deposit contract block number URL |
 | devnet.urls.genesisSsz | string | `"{{ .Values.devnet.baseUrl }}/{{ .Values.devnet.name }}/metadata/genesis.ssz"` | Genesis state SSZ URL |
+| existingJwtSecret | string | `""` | Use an existing Secret for the JWT instead of creating one (e.g. managed by an external secrets operator). The Secret must contain the key `jwt.hex` with the JWT secret as a hex string. When set, `jwt` is ignored. |
 | extraArgs | list | `[]` | Extra args for the teku container |
 | extraContainers | list | `[]` | Additional containers |
 | extraEnv | list | `[]` | Additional env variables |
@@ -109,6 +110,14 @@ An open-source Ethereum 2.0 client, written in Java
 | updateStrategy.type | string | `"RollingUpdate"` | Update strategy type |
 
 # Examples
+
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
 
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 

--- a/charts/teku/README.md.gotmpl
+++ b/charts/teku/README.md.gotmpl
@@ -16,6 +16,14 @@
 
 # Examples
 
+## Using an existing JWT Secret
+
+If the JWT secret is managed outside of Helm (e.g. by an external secrets operator such as External Secrets, Vault or Doppler), reference it instead of letting the chart create one. The Secret must contain the JWT secret as a hex string under the key `jwt.hex`:
+
+```yaml
+existingJwtSecret: my-jwt-secret
+```
+
 ## Beacon node on the Holesky testnet connected to Holesky via Infura
 
 ```yaml

--- a/charts/teku/templates/secret.yaml
+++ b/charts/teku/templates/secret.yaml
@@ -8,6 +8,7 @@ data:
 {{- range $key, $value := .Values.secretEnv }}
   {{ $key }}: {{ $value | b64enc }}
 {{- end }}
+{{- if not .Values.existingJwtSecret }}
 ---
 apiVersion: v1
 kind: Secret
@@ -16,3 +17,4 @@ metadata:
 type: Opaque
 data:
   jwt.hex: {{ .Values.jwt | b64enc }}
+{{- end }}

--- a/charts/teku/templates/statefulset.yaml
+++ b/charts/teku/templates/statefulset.yaml
@@ -168,7 +168,7 @@ spec:
       volumes:
         - name: jwt
           secret:
-            secretName: {{ include "teku.fullname" . }}-jwt
+            secretName: {{ .Values.existingJwtSecret | default (printf "%s-jwt" (include "teku.fullname" .)) }}
       {{- if .Values.p2pNodePort.enabled }}
         - name: env-nodeport
           emptyDir: {}

--- a/charts/teku/values.yaml
+++ b/charts/teku/values.yaml
@@ -31,6 +31,11 @@ extraArgs: []
 # -- JWT secret used by client as a secret. Change this value.
 jwt: ecb22bc24e7d4061f7ed690ccd5846d7d73f5d2b9733267e12f56790398d908a
 
+# -- Use an existing Secret for the JWT instead of creating one (e.g. managed
+# by an external secrets operator). The Secret must contain the key `jwt.hex`
+# with the JWT secret as a hex string. When set, `jwt` is ignored.
+existingJwtSecret: ""
+
 # -- Checkpoint Sync
 checkpointSync:
   enabled: false


### PR DESCRIPTION
# Description

When configuring the JWT secret for reth + lighthouse, the secret can't be managed outside of the values file, which makes publishing values files (Git, buckets) impossible while retaining the same security standards. This PR introduces a well-known pattern of referencing external secrets for the JWT token (to all EL/CL charts).

# Tests

- [x] `pre-commit run --all-files`
- [x] `make lint`
- [x] `helm test` on a local kind cluster