### PR TITLE
feat(slashoor): add chart for the beacon chain slasher

### DIFF
--- a/charts/slashoor/.helmignore
+++ b/charts/slashoor/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/slashoor/Chart.yaml
+++ b/charts/slashoor/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: slashoor
+description: A beacon chain slasher that detects and submits attester and proposer slashings
+home: https://github.com/ethpandaops/slashoor
+type: application
+version: 0.1.0
+maintainers:
+  - name: barnabasbusa
+    email: busa.barnabas@gmail.com

--- a/charts/slashoor/README.md
+++ b/charts/slashoor/README.md
@@ -1,0 +1,54 @@
+# slashoor
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+A beacon chain slasher that detects and submits attester and proposer slashings
+
+**Homepage:** <https://github.com/ethpandaops/slashoor>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity |
+| annotations | object | `{}` | Annotations for the Deployment |
+| args | list | `[]` | Command arguments |
+| config.backfill_slots | int | `320` | Number of recent slots to backfill attestations for on startup. Committee resolution for deep history needs archive states, so keep this within a few epochs; the Dora scan covers older proposer slashings. |
+| config.beacon.endpoints | list | `["http://localhost:5052"]` | Beacon node API endpoints; multiple endpoints get automatic failover |
+| config.beacon.timeout | string | `"30s"` |  |
+| config.detector.enabled | bool | `true` |  |
+| config.dora.enabled | bool | `false` | Enable the Dora explorer integration for historical double-proposal scanning |
+| config.dora.scan_on_startup | bool | `true` |  |
+| config.dora.url | string | `"https://dora.example.com"` |  |
+| config.indexer.max_epochs_to_keep | int | `54000` | Attestation retention window in epochs |
+| config.proposer.enabled | bool | `true` |  |
+| config.submitter.dry_run | bool | `false` | If true, log slashings without submitting them |
+| config.submitter.enabled | bool | `true` |  |
+| containerSecurityContext | object | `{}` | Container security context |
+| customArgs | list | `[]` | Custom args for the custom command |
+| customCommand | list | `[]` | Custom command to override the default entrypoint |
+| extraContainers | list | `[]` | Additional containers |
+| extraEnv | list | `[]` | Additional env variables |
+| extraVolumeMounts | list | `[]` | Additional volume mounts |
+| extraVolumes | list | `[]` | Additional volumes |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| image.pullPolicy | string | `"IfNotPresent"` | slashoor container pull policy |
+| image.repository | string | `"ethpandaops/slashoor"` | slashoor container image repository |
+| image.tag | string | `"latest"` | slashoor container image tag |
+| imagePullSecrets | list | `[]` | Image pull secrets |
+| initContainers | list | `[]` | Init containers |
+| logLevel | string | `"info"` | Log level (debug, info, warn, error) |
+| nameOverride | string | `""` | Overrides the chart's name |
+| nodeSelector | object | `{}` | Node selector |
+| podAnnotations | object | `{}` | Pod annotations |
+| podLabels | object | `{}` | Pod labels |
+| priorityClassName | string | `""` | Priority class name |
+| replicas | int | `1` | Number of replicas. Keep at 1: multiple instances race to submit the same slashings, which is harmless (the pool dedupes) but noisy. |
+| resources | object | `{}` | Resource requests and limits |
+| securityContext | object | `{"runAsNonRoot":false}` | Pod security context |
+| serviceAccount.annotations | object | `{}` | Annotations for the service account |
+| serviceAccount.create | bool | `true` | If true, a service account will be created |
+| serviceAccount.name | string | `""` | Name of the service account, computed from the fullname if empty |
+| terminationGracePeriodSeconds | int | `30` | Termination grace period in seconds |
+| tolerations | list | `[]` | Tolerations |
+| topologySpreadConstraints | list | `[]` | Topology spread constraints |

--- a/charts/slashoor/README.md.gotmpl
+++ b/charts/slashoor/README.md.gotmpl
@@ -1,0 +1,14 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}

--- a/charts/slashoor/ci/ct-values.yaml
+++ b/charts/slashoor/ci/ct-values.yaml
@@ -5,3 +5,21 @@ config:
   submitter:
     enabled: true
     dry_run: true
+
+# Exercise the injected-list options so CI catches indentation regressions.
+extraVolumes:
+  - name: extra
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: extra
+    mountPath: /extra
+
+extraContainers:
+  - name: sidecar
+    image: busybox:1.36
+    command: ["sleep", "infinity"]
+
+extraEnv:
+  - name: EXTRA_ENV
+    value: "1"

--- a/charts/slashoor/ci/ct-values.yaml
+++ b/charts/slashoor/ci/ct-values.yaml
@@ -1,0 +1,7 @@
+config:
+  beacon:
+    endpoints:
+      - "http://beacon-node:5052"
+  submitter:
+    enabled: true
+    dry_run: true

--- a/charts/slashoor/templates/NOTES.txt
+++ b/charts/slashoor/templates/NOTES.txt
@@ -1,0 +1,13 @@
+slashoor has been deployed.
+
+It watches the configured beacon nodes for slashable offenses and submits
+attester and proposer slashings to the pool.
+
+Check what it's doing:
+
+  kubectl logs -n {{ .Release.Namespace }} deployment/{{ include "slashoor.fullname" . }} -f
+
+{{- if .Values.config.submitter.dry_run }}
+
+NOTE: submitter.dry_run is enabled — detected slashings are logged but NOT submitted.
+{{- end }}

--- a/charts/slashoor/templates/_helpers.tpl
+++ b/charts/slashoor/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "slashoor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "slashoor.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "slashoor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "slashoor.labels" -}}
+helm.sh/chart: {{ include "slashoor.chart" . }}
+{{ include "slashoor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "slashoor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "slashoor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "slashoor.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "slashoor.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/slashoor/templates/configmap.yaml
+++ b/charts/slashoor/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "slashoor.fullname" . }}
+  labels:
+    {{- include "slashoor.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+    {{- toYaml .Values.config | nindent 4 }}

--- a/charts/slashoor/templates/deployment.yaml
+++ b/charts/slashoor/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             subPath: config.yaml
             readOnly: true
           {{- if .Values.extraVolumeMounts }}
-            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
           {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
@@ -74,7 +74,7 @@ spec:
           {{- toYaml .Values.extraEnv | nindent 12 }}
         {{- end }}
       {{- if .Values.extraContainers }}
-        {{ toYaml .Values.extraContainers | nindent 8}}
+        {{- toYaml .Values.extraContainers | nindent 6 }}
       {{- end }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/charts/slashoor/templates/deployment.yaml
+++ b/charts/slashoor/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "slashoor.fullname" . }}
+  labels:
+    {{- include "slashoor.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "slashoor.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "slashoor.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "slashoor.serviceAccountName" . }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+    {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      initContainers:
+      {{- if .Values.initContainers }}
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        {{- if gt (len .Values.customCommand) 0 }}
+          {{- toYaml .Values.customCommand | nindent 12}}
+        {{- else }}
+          - "/app/slashoor"
+          - --config=/config.yaml
+          - --log-level={{ .Values.logLevel }}
+          {{- if gt (len .Values.args) 0 }}
+          {{- toYaml .Values.args | nindent 12}}
+          {{- end }}
+        {{- end }}
+        {{- if gt (len .Values.customArgs) 0 }}
+        args:
+          {{- toYaml .Values.customArgs | nindent 12}}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+        volumeMounts:
+          - name: config
+            mountPath: "/config.yaml"
+            subPath: config.yaml
+            readOnly: true
+          {{- if .Values.extraVolumeMounts }}
+            {{ toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.extraEnv }}
+        env:
+          {{- toYaml .Values.extraEnv | nindent 12 }}
+        {{- end }}
+      {{- if .Values.extraContainers }}
+        {{ toYaml .Values.extraContainers | nindent 8}}
+      {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      volumes:
+      {{- if .Values.extraVolumes }}
+        {{ toYaml .Values.extraVolumes | nindent 8}}
+      {{- end }}
+        - name: config
+          configMap:
+            name: {{ include "slashoor.fullname" . }}

--- a/charts/slashoor/templates/serviceaccount.yaml
+++ b/charts/slashoor/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "slashoor.serviceAccountName" . }}
+  labels:
+    {{- include "slashoor.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/slashoor/values.yaml
+++ b/charts/slashoor/values.yaml
@@ -1,0 +1,131 @@
+# -- Overrides the chart's name
+nameOverride: ""
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+# -- Number of replicas. Keep at 1: multiple instances race to submit the
+# same slashings, which is harmless (the pool dedupes) but noisy.
+replicas: 1
+
+image:
+  # -- slashoor container image repository
+  repository: ethpandaops/slashoor
+  # -- slashoor container image tag
+  tag: latest
+  # -- slashoor container pull policy
+  pullPolicy: IfNotPresent
+
+# -- Log level (debug, info, warn, error)
+logLevel: info
+
+# -- Command arguments
+args: []
+
+# -- Custom command to override the default entrypoint
+customCommand: []
+
+# -- Custom args for the custom command
+customArgs: []
+
+config:
+  beacon:
+    # -- Beacon node API endpoints; multiple endpoints get automatic failover
+    endpoints:
+      - "http://localhost:5052"
+    timeout: 30s
+
+  indexer:
+    # -- Attestation retention window in epochs
+    max_epochs_to_keep: 54000
+
+  detector:
+    enabled: true
+
+  submitter:
+    enabled: true
+    # -- If true, log slashings without submitting them
+    dry_run: false
+
+  proposer:
+    enabled: true
+
+  dora:
+    # -- Enable the Dora explorer integration for historical double-proposal scanning
+    enabled: false
+    url: "https://dora.example.com"
+    scan_on_startup: true
+
+  # -- Number of recent slots to backfill attestations for on startup.
+  # Committee resolution for deep history needs archive states, so keep this
+  # within a few epochs; the Dora scan covers older proposer slashings.
+  backfill_slots: 320
+
+serviceAccount:
+  # -- If true, a service account will be created
+  create: true
+  # -- Annotations for the service account
+  annotations: {}
+  # -- Name of the service account, computed from the fullname if empty
+  name: ""
+
+# -- Annotations for the Deployment
+annotations: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod security context
+securityContext:
+  runAsNonRoot: false
+
+# -- Container security context
+containerSecurityContext: {}
+
+# -- Image pull secrets
+imagePullSecrets: []
+
+# -- Priority class name
+priorityClassName: ""
+
+# -- Init containers
+initContainers: []
+
+# -- Additional containers
+extraContainers: []
+
+# -- Resource requests and limits
+resources: {}
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+  # limits:
+  #   cpu: 500m
+  #   memory: 1Gi
+
+# -- Node selector
+nodeSelector: {}
+
+# -- Affinity
+affinity: {}
+
+# -- Tolerations
+tolerations: []
+
+# -- Topology spread constraints
+topologySpreadConstraints: []
+
+# -- Termination grace period in seconds
+terminationGracePeriodSeconds: 30
+
+# -- Additional volumes
+extraVolumes: []
+
+# -- Additional volume mounts
+extraVolumeMounts: []
+
+# -- Additional env variables
+extraEnv: []


### PR DESCRIPTION
Adds a chart for [slashoor](https://github.com/ethpandaops/slashoor), the beacon chain slasher — intended to run one instance per devnet alongside dora.

- Single-replica stateless Deployment (no PVC: state is rebuilt on startup from the attestation backfill + Dora historical scan; >1 replica just races to submit the same slashings)
- Config rendered to a ConfigMap: beacon endpoints (client has multi-node failover), Dora URL + `scan_on_startup` for historical double proposals, `submitter.dry_run` toggle
- No Service/ServiceMonitor yet — the process exposes no HTTP ports (metrics endpoint is a planned follow-up)
- `helm lint` + `helm template` pass with `ci/ct-values.yaml`; README generated with helm-docs v1.14.2

Tested against glamsterdam-devnet-7 (Gloas) with image `ethpandaops/slashoor` from today's `v0.1.0` release.