### PR TITLE
feat(mempool-lens): add chart for the mempool-lens transaction lifecycle viewer

### DIFF
--- a/charts/mempool-lens/.helmignore
+++ b/charts/mempool-lens/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/mempool-lens/Chart.yaml
+++ b/charts/mempool-lens/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: mempool-lens
+description: >
+  Live transaction-lifecycle viewer for go-ethereum's txtracker and peerstats
+  JSON-RPC namespaces. Connects to an instrumented geth node over WebSocket
+  and renders mempool status transitions, peer stats and flow diagrams in a
+  small web UI.
+home: https://github.com/cskiraly/mempool-lens
+sources:
+  - https://github.com/cskiraly/mempool-lens
+type: application
+version: 0.1.0
+maintainers:
+  - name: barnabasbusa
+    email: busa.barnabas@gmail.com

--- a/charts/mempool-lens/README.md
+++ b/charts/mempool-lens/README.md
@@ -1,0 +1,88 @@
+# mempool-lens
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+Live transaction-lifecycle viewer for go-ethereum's txtracker and peerstats JSON-RPC namespaces. Connects to an instrumented geth node over WebSocket and renders mempool status transitions, peer stats and flow diagrams in a small web UI.
+
+**Homepage:** <https://github.com/cskiraly/mempool-lens>
+
+## Source Code
+
+* <https://github.com/cskiraly/mempool-lens>
+
+# Usage
+
+Runs `lens --addr 0.0.0.0:<httpPort> --rpc <rpcUrl> --proxy` and serves the
+UI on the configured port. `rpcUrl` must point at the WebSocket endpoint of a
+geth build that has the `txtracker` namespace enabled
+(`geth --ws --ws.api txtracker,peerstats,admin`); without `peerstats`/`admin`
+the Peers tab columns stay empty but the rest of the UI works.
+
+In proxy mode (default) the browser talks only to the lens, which proxies the
+geth WebSocket via `/ws` — recommended behind an ingress. Auth tokens, method
+allow-lists and a GeoLite2 database can be wired up through `extraArgs` (and
+`extraVolumes`/`extraVolumeMounts` for the mmdb file).
+
+Example values:
+```yaml
+rpcUrl: ws://geth-instrumented:8546
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: mempool-lens.example.io
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity configuration for pods |
+| annotations | object | `{}` | Annotations for the Deployment |
+| containerSecurityContext | object | `{}` | The security context for containers |
+| customCommand | list | `[]` | Override the command. Leave empty to use the chart default. |
+| extraArgs | list | `[]` | Extra args appended to the mempool-lens command (e.g. auth tokens, --geo-db, --allow-methods) |
+| extraContainers | list | `[]` | Additional containers |
+| extraEnv | list | `[]` | Additional env variables passed to the mempool-lens container |
+| extraPorts | list | `[]` | Additional ports. Useful when using extraContainers |
+| extraVolumeMounts | list | `[]` | Additional volume mounts |
+| extraVolumes | list | `[]` | Additional volumes |
+| fullnameOverride | string | `""` | Overrides the chart's computed fullname |
+| httpPort | int | `8670` | HTTP port the mempool-lens UI listens on |
+| image.pullPolicy | string | `"Always"` | mempool-lens container pull policy |
+| image.repository | string | `"bbusa/mempool-lens"` | mempool-lens container image repository |
+| image.tag | string | `"latest"` | mempool-lens container image tag |
+| imagePullSecrets | list | `[]` | ImagePullSecrets for the pod |
+| ingress.annotations | object | `{}` | Annotations for Ingress |
+| ingress.className | string | `""` | Ingress class |
+| ingress.enabled | bool | `false` | Ingress resource for the HTTP UI |
+| ingress.hosts[0].host | string | `"chart-example.local"` |  |
+| ingress.hosts[0].paths[0].path | string | `"/"` |  |
+| ingress.hosts[0].paths[0].pathType | string | `"Prefix"` |  |
+| ingress.tls | list | `[]` | Ingress TLS |
+| initContainers | list | `[]` | Additional init containers |
+| livenessProbe | object | `{"httpGet":{"path":"/","port":"http"},"initialDelaySeconds":5,"periodSeconds":10}` | Liveness probe |
+| nameOverride | string | `""` | Overrides the chart's name |
+| nodeSelector | object | `{}` | Node selector for pods |
+| podAnnotations | object | `{}` | Pod annotations |
+| podDisruptionBudget | object | `{}` | Define the PodDisruptionBudget spec. If not set then a PodDisruptionBudget will not be created. |
+| podLabels | object | `{}` | Pod labels |
+| priorityClassName | string | `nil` | Pod priority class |
+| proxy | bool | `true` | Run in proxy mode: the lens proxies the geth WebSocket for browsers via /ws instead of the browser connecting to geth directly. Recommended when serving the UI through an ingress. Note: in proxy mode the process exits at startup if the RPC endpoint is unreachable (kubernetes will restart it). |
+| readinessProbe | object | `{"httpGet":{"path":"/","port":"http"},"initialDelaySeconds":2,"periodSeconds":5}` | Readiness probe |
+| replicas | int | `1` | Number of replicas |
+| resources | object | `{}` | Resource requests and limits |
+| rpcUrl | string | `"ws://localhost:8546"` | WebSocket endpoint of a geth node with the txtracker (and optionally peerstats/admin) namespaces enabled on the WS API |
+| securityContext | object | `{"fsGroup":10001,"runAsGroup":10001,"runAsNonRoot":true,"runAsUser":10001}` | The security context for pods |
+| service.nodePort | string | `""` | NodePort (only used when service.type is NodePort) |
+| service.type | string | `"ClusterIP"` | Service type |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| terminationGracePeriodSeconds | int | `30` | How long to wait until the pod is forcefully terminated |
+| tolerations | list | `[]` | Tolerations for pods |
+| topologySpreadConstraints | list | `[]` | Topology Spread Constraints for pods |
+| updateStrategy | object | `{"type":"RollingUpdate"}` | Update strategy for the Deployment |

--- a/charts/mempool-lens/README.md.gotmpl
+++ b/charts/mempool-lens/README.md.gotmpl
@@ -1,0 +1,42 @@
+{{ template "chart.header" . }}
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}
+
+{{ template "chart.description" . }}
+
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+
+# Usage
+
+Runs `lens --addr 0.0.0.0:<httpPort> --rpc <rpcUrl> --proxy` and serves the
+UI on the configured port. `rpcUrl` must point at the WebSocket endpoint of a
+geth build that has the `txtracker` namespace enabled
+(`geth --ws --ws.api txtracker,peerstats,admin`); without `peerstats`/`admin`
+the Peers tab columns stay empty but the rest of the UI works.
+
+In proxy mode (default) the browser talks only to the lens, which proxies the
+geth WebSocket via `/ws` — recommended behind an ingress. Auth tokens, method
+allow-lists and a GeoLite2 database can be wired up through `extraArgs` (and
+`extraVolumes`/`extraVolumeMounts` for the mmdb file).
+
+Example values:
+```yaml
+rpcUrl: ws://geth-instrumented:8546
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: mempool-lens.example.io
+      paths:
+        - path: /
+          pathType: Prefix
+```
+
+{{ template "chart.valuesSection" . }}

--- a/charts/mempool-lens/ci/ct-values.yaml
+++ b/charts/mempool-lens/ci/ct-values.yaml
@@ -1,0 +1,23 @@
+# Values used by chart-testing (ct install) in CI.
+# Proxy mode is disabled so the pod starts without a reachable geth RPC
+# endpoint (in proxy mode the process exits at startup if the RPC probe
+# fails).
+proxy: false
+
+# Exercise the optional pod wiring to catch indentation regressions.
+extraEnv:
+  - name: EXTRA_ENV_TEST
+    value: "true"
+
+extraVolumes:
+  - name: geoip
+    emptyDir: {}
+
+extraVolumeMounts:
+  - name: geoip
+    mountPath: /app/data
+
+extraContainers:
+  - name: sidecar-test
+    image: busybox:1.36
+    command: ["sh", "-c", "sleep infinity"]

--- a/charts/mempool-lens/templates/NOTES.txt
+++ b/charts/mempool-lens/templates/NOTES.txt
@@ -1,0 +1,20 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "mempool-lens.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "mempool-lens.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "mempool-lens.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.httpPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "mempool-lens.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME {{ .Values.httpPort }}:{{ .Values.httpPort }}
+{{- end }}

--- a/charts/mempool-lens/templates/_helpers.tpl
+++ b/charts/mempool-lens/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mempool-lens.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mempool-lens.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mempool-lens.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mempool-lens.labels" -}}
+helm.sh/chart: {{ include "mempool-lens.chart" . }}
+{{ include "mempool-lens.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mempool-lens.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mempool-lens.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "mempool-lens.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "mempool-lens.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/mempool-lens/templates/deployment.yaml
+++ b/charts/mempool-lens/templates/deployment.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mempool-lens.fullname" . }}
+  labels:
+    {{- include "mempool-lens.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicas }}
+  strategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  selector:
+    matchLabels:
+      {{- include "mempool-lens.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "mempool-lens.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: {{ include "mempool-lens.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.initContainers }}
+      initContainers:
+        {{- toYaml .Values.initContainers | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if gt (len .Values.customCommand) 0 }}
+          command:
+            {{- toYaml .Values.customCommand | nindent 12 }}
+          {{- end }}
+          args:
+            {{- if gt (len .Values.customCommand) 0 }}
+            {{- toYaml .Values.extraArgs | nindent 12 }}
+            {{- else }}
+            - "--addr=0.0.0.0:{{ .Values.httpPort }}"
+            - "--rpc={{ .Values.rpcUrl }}"
+            {{- if .Values.proxy }}
+            - "--proxy"
+            {{- end }}
+            {{- if gt (len .Values.extraArgs) 0 }}
+            {{- toYaml .Values.extraArgs | nindent 12 }}
+            {{- end }}
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.httpPort }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.extraEnv .Values.extraVolumeMounts }}
+          {{- if .Values.extraEnv }}
+          env:
+            {{- toYaml .Values.extraEnv | nindent 12 }}
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- end }}
+          {{- end }}
+        {{- if .Values.extraContainers }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+        {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      topologySpreadConstraints:
+        {{- toYaml .Values.topologySpreadConstraints | nindent 8 }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- if .Values.extraVolumes }}
+      volumes:
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}

--- a/charts/mempool-lens/templates/ingress.yaml
+++ b/charts/mempool-lens/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "mempool-lens.fullname" . -}}
+{{- $svcPort := .Values.httpPort -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "mempool-lens.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/mempool-lens/templates/service.yaml
+++ b/charts/mempool-lens/templates/service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "mempool-lens.fullname" . }}
+  labels:
+    {{- include "mempool-lens.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.httpPort }}
+      targetPort: http
+      protocol: TCP
+      name: http
+      {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+    {{- if .Values.extraPorts }}
+    {{- toYaml .Values.extraPorts | nindent 4 }}
+    {{- end }}
+  selector:
+    {{- include "mempool-lens.selectorLabels" . | nindent 4 }}

--- a/charts/mempool-lens/templates/serviceaccount.yaml
+++ b/charts/mempool-lens/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "mempool-lens.serviceAccountName" . }}
+  labels:
+    {{- include "mempool-lens.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/mempool-lens/values.yaml
+++ b/charts/mempool-lens/values.yaml
@@ -1,0 +1,170 @@
+# -- Overrides the chart's name
+nameOverride: ""
+
+# -- Overrides the chart's computed fullname
+fullnameOverride: ""
+
+# -- Number of replicas
+replicas: 1
+
+image:
+  # -- mempool-lens container image repository
+  repository: bbusa/mempool-lens
+  # -- mempool-lens container image tag
+  tag: latest
+  # -- mempool-lens container pull policy
+  pullPolicy: Always
+
+# -- HTTP port the mempool-lens UI listens on
+httpPort: 8670
+
+# -- WebSocket endpoint of a geth node with the txtracker (and optionally
+# peerstats/admin) namespaces enabled on the WS API
+rpcUrl: ws://localhost:8546
+
+# -- Run in proxy mode: the lens proxies the geth WebSocket for browsers via
+# /ws instead of the browser connecting to geth directly. Recommended when
+# serving the UI through an ingress. Note: in proxy mode the process exits at
+# startup if the RPC endpoint is unreachable (kubernetes will restart it).
+proxy: true
+
+# -- Override the command. Leave empty to use the chart default.
+customCommand: []
+
+# -- Extra args appended to the mempool-lens command (e.g. auth tokens,
+# --geo-db, --allow-methods)
+extraArgs: []
+
+ingress:
+  # -- Ingress resource for the HTTP UI
+  enabled: false
+  # -- Ingress class
+  className: ""
+  # -- Annotations for Ingress
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # -- Ingress hosts
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: Prefix
+  # -- Ingress TLS
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+service:
+  # -- Service type
+  type: ClusterIP
+  # -- NodePort (only used when service.type is NodePort)
+  nodePort: ""
+
+# -- Affinity configuration for pods
+affinity: {}
+
+# -- Annotations for the Deployment
+annotations: {}
+
+# -- Node selector for pods
+nodeSelector: {}
+
+# -- Pod labels
+podLabels: {}
+
+# -- Pod annotations
+podAnnotations: {}
+
+# -- Pod priority class
+priorityClassName: null
+
+# -- Resource requests and limits
+resources: {}
+# limits:
+#   cpu: 200m
+#   memory: 256Mi
+# requests:
+#   cpu: 50m
+#   memory: 64Mi
+
+# -- The security context for pods
+securityContext:
+  fsGroup: 10001
+  runAsGroup: 10001
+  runAsNonRoot: true
+  runAsUser: 10001
+
+# -- The security context for containers
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 10001
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# -- How long to wait until the pod is forcefully terminated
+terminationGracePeriodSeconds: 30
+
+# -- Tolerations for pods
+tolerations: []
+
+# -- Topology Spread Constraints for pods
+topologySpreadConstraints: []
+
+# -- Define the PodDisruptionBudget spec. If not set then a PodDisruptionBudget will not be created.
+podDisruptionBudget: {}
+# minAvailable: 1
+# maxUnavailable: 1
+
+# -- Update strategy for the Deployment
+updateStrategy:
+  type: RollingUpdate
+
+# -- Additional init containers
+initContainers: []
+
+# -- Additional containers
+extraContainers: []
+
+# -- Additional volumes
+extraVolumes: []
+
+# -- Additional volume mounts
+extraVolumeMounts: []
+
+# -- Additional ports. Useful when using extraContainers
+extraPorts: []
+
+# -- Additional env variables passed to the mempool-lens container
+extraEnv: []
+
+# -- Liveness probe
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 5
+  periodSeconds: 10
+
+# -- Readiness probe
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+  initialDelaySeconds: 2
+  periodSeconds: 5
+
+# -- ImagePullSecrets for the pod
+imagePullSecrets: []


### PR DESCRIPTION
Adds a chart for [mempool-lens](https://github.com/cskiraly/mempool-lens), a live transaction-lifecycle viewer for geth's `txtracker`/`peerstats` JSON-RPC namespaces.

- Standard deployment + service + ingress + serviceaccount layout (modeled on `buildoor-overview`).
- Defaults: serves the UI on `httpPort: 8670`, runs in `--proxy` mode so browsers only talk to the lens (it proxies the geth WebSocket via `/ws`), `rpcUrl` points at the instrumented geth WS endpoint.
- Image defaults to `bbusa/mempool-lens` for now; will switch to the upstream image once [cskiraly/mempool-lens#1](https://github.com/cskiraly/mempool-lens/pull/1) lands and publishes one.
- `ci/ct-values.yaml` disables proxy mode so `ct install` works without a reachable RPC endpoint, and exercises `extraEnv`/`extraVolumes`/`extraVolumeMounts`/`extraContainers`.
- `helm lint` + `helm template` pass with default and CI values; README generated with helm-docs.

https://claude.ai/code/session_019FXty3nj4rtVjkeSzSysmh